### PR TITLE
Fix picard wgs metrics outpath

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,8 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.1.1
 commit = True
 tag = False
 
 [bumpversion:file:pyproject.toml]
+
 [bumpversion:file:.github/workflows/docker.yaml]

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ on:
 permissions: {}
 
 env:
-  VERSION: 0.1.0
+  VERSION: 0.1.1
   IMAGE_NAME: cpg-flow-align-genotype
   DOCKER_DEV: australia-southeast1-docker.pkg.dev/cpg-common/images-dev
   DOCKER_MAIN: australia-southeast1-docker.pkg.dev/cpg-common/images

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='Dragmap align & genotype workflow, using CPG-Flow'
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.11"
-version='0.1.0'
+version='0.1.1'
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',

--- a/src/align_genotype/stages.py
+++ b/src/align_genotype/stages.py
@@ -208,7 +208,7 @@ class CramQcPicardCollectMetrics(stage.SequencingGroupStage):
         qc_prefix = sequencing_group.dataset.prefix() / 'qc'
         # genomes use wgs, exome uses hs - this is in the path and file extension
         qc_type = 'wgs' if sequencing_group.sequencing_type == 'genome' else 'hs'
-        return qc_prefix / f'picard-{qc_type}-metrics/{sequencing_group.id}.picard-{qc_type}-metrics'
+        return qc_prefix / f'picard_{qc_type}_metrics/{sequencing_group.id}.picard-{qc_type}-metrics'
 
     def queue_jobs(self, sequencing_group: targets.SequencingGroup, inputs: stage.StageInput) -> stage.StageOutput:
         output = self.expected_outputs(sequencing_group)


### PR DESCRIPTION
# Purpose

  - Fixes the expected_outputs path for the picard collect metrics stage

The actual output location for these files is like: 
`gs://cpg-dataset-main/qc/picard_wgs_metrics/CPGXXXXXX.picard-wgs-metrics`

Confusing because the dir has underscores but the extension has dashes. 