### PR TITLE
Picard metrics job resources

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.3
+current_version = 0.1.4
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ on:
 permissions: {}
 
 env:
-  VERSION: 0.1.3
+  VERSION: 0.1.4
   IMAGE_NAME: cpg-flow-align-genotype
   DOCKER_DEV: australia-southeast1-docker.pkg.dev/cpg-common/images-dev
   DOCKER_MAIN: australia-southeast1-docker.pkg.dev/cpg-common/images

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This single-sample workflow has a dedicated entrypoint, and can be operated thro
 
 ```bash
 analysis-runner --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.1.3 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.1.4 \
     --config CONFIG_FILE.toml \
     --dataset seqr \
     --description 'Single-Sample data generation' \
@@ -38,7 +38,7 @@ A secondary workflow continues on from the single-sample steps, and produces Dat
 This Dataset-level workflow can be run in a similar way, but with a different entrypoint:
 ```bash
 analysis-runner --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.1.3 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.1.4 \
     --config CONFIG_FILE.toml \
     --dataset seqr \
     --description 'Dataset-Level QC workflow' \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='Dragmap align & genotype workflow, using CPG-Flow'
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.11"
-version='0.1.3'
+version='0.1.4'
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',

--- a/src/align_genotype/config_template.toml
+++ b/src/align_genotype/config_template.toml
@@ -30,6 +30,9 @@ reblock_gq_bands = [13, 20, 30, 40]
 # set to assign a specific amount of RAM to the picard jobs, defaults available
 #picard_mem_gb
 
+# set to use highmem workers for picard qc metrics jobs, defaults to false
+picard_metrics_use_highmem = false
+
 # set to override the picard attached storage, default 250
 picard_storage_gb = 250
 

--- a/src/align_genotype/jobs/picard.py
+++ b/src/align_genotype/jobs/picard.py
@@ -164,13 +164,13 @@ def get_intervals(
     return job, intervals
 
 
-def get_metrics_job_resources():
+def get_metrics_job_resources(ncpu: int = 2, mem_gb: int = 8) -> resources.JobResource:
     """
     Get the resources for Picard metrics jobs.
     """
     if config.config_retrieve(['workflow', 'picard_metrics_use_highmem'], default=False):
         return resources.HIGHMEM.request_resources(ncpu=4, mem_gb=16)
-    return resources.STANDARD.request_resources(ncpu=2, mem_gb=8)  # Default memory for metrics jobs
+    return resources.STANDARD.request_resources(ncpu=ncpu, mem_gb=mem_gb)  # Default memory for metrics jobs
 
 
 def collect_metrics(
@@ -380,7 +380,10 @@ def vcf_qc(
     )
     job.image(config.config_retrieve(['images', 'picard']))
 
-    res = resources.STANDARD.set_resources(j=job, storage_gb=20, mem_gb=3)
+    res = get_metrics_job_resources(mem_gb=3)
+    sequencing_type = config.config_retrieve(['workflow', 'sequencing_type'])
+    res.attach_disk_storage_gb = config.config_retrieve(['workflow', f'{sequencing_type}_cram_gb'])
+    res.set_to_job(job)
 
     dbsnp_vcf = config.config_retrieve(['references', 'dbsnp_vcf'])
     dbsnp_vcf_localised = batch_instance.read_input_group(


### PR DESCRIPTION
# Purpose

  - Allow user configurable machine type (HIGHMEM / STANDARD) for Picard QC jobs (`collect_metrics`, `hs_metrics`, `wgs_metrics`, `vcf_qc`)
  - User should set to HIGHMEM for samples which need more memory, e.g. for WGS samples [here](https://batch.hail.populationgenomics.org.au/batches/630223?q=state%3Dbad%0D%0Aname%3D%7EPicard) or WES samples [here](https://batch.hail.populationgenomics.org.au/batches/630313?q=state%3Dbad%0D%0Aname%3D%7EPicard) 
  
## Proposed Changes

  - Add a new default config entry for the boolean `workflow.picard_metrics_use_highmem`
  - Add a new function to read the config for this bool
     - The function can take some values, to maintain the existing `mem_gb=3` used by the `vcf_qc` job
     - Otherwise, defaults to STANDARD machine type with 2 cpu and 8 gb memory
  - Standardise the way the machine type and resources are set for each job, by:
     - 1. Getting the machine type, memory, and ncpu with the new function
     - 2. Get the disk storage from config default or override (`workflow.{sequencing_type}_cram_gb`)
     - 3. Call `res.set_to_job(job)` to finalise the resource request


