### PR TITLE
Fix scatter bottleneck

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ on:
 permissions: {}
 
 env:
-  VERSION: 0.1.7
+  VERSION: 0.2.0
   IMAGE_NAME: cpg-flow-align-genotype
   DOCKER_DEV: australia-southeast1-docker.pkg.dev/cpg-common/images-dev
   DOCKER_MAIN: australia-southeast1-docker.pkg.dev/cpg-common/images

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This single-sample workflow has a dedicated entrypoint, and can be operated thro
 
 ```bash
 analysis-runner --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.1.7 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.2.0 \
     --config CONFIG_FILE.toml \
     --dataset seqr \
     --description 'Single-Sample data generation' \
@@ -38,7 +38,7 @@ A secondary workflow continues on from the single-sample steps, and produces Dat
 This Dataset-level workflow can be run in a similar way, but with a different entrypoint:
 ```bash
 analysis-runner --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.1.7 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.2.0 \
     --config CONFIG_FILE.toml \
     --dataset seqr \
     --description 'Dataset-Level QC workflow' \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='Dragmap align & genotype workflow, using CPG-Flow'
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.11"
-version='0.1.7'
+version="0.2.0"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -111,7 +111,7 @@ section-order = ["future", "standard-library", "third-party", "first-party", "lo
 "src/align_genotype/jobs/somalier.py" = ["C901", "PLR0912", "PLR0913", "PLR0915"]  # ignore complexity for this script
 
 [tool.bumpversion]
-current_version = "0.1.7"
+current_version = "0.2.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ ignore = [
     "PLW0603", # Using the global statement to update `<VAR>` is discouraged
     "Q000", # Single quotes found but double quotes preferred
     "PD901", # Avoid using the generic variable name `df` for DataFrames
+    "PLR0913", # Too many arguments in function definition (6 > 5)
 ]
 
 [tool.ruff.lint.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,7 @@ commit_args = ""
 
 [[tool.bumpversion.files]]
 filename = "pyproject.toml"
-search = 'version="{current_version}"'
+search = "version='{current_version}'"
 replace = 'version="{new_version}"'
 
 [[tool.bumpversion.files]]

--- a/src/align_genotype/jobs/align.py
+++ b/src/align_genotype/jobs/align.py
@@ -354,7 +354,7 @@ def sort_cmd(requested_nthreads: int) -> str:
     ).strip()
 
 
-def finalise_alignment(  # noqa: PLR0913
+def finalise_alignment(
     align_cmd: str,
     stdout_is_sorted: bool,
     job: BashJob,

--- a/src/align_genotype/jobs/genotype.py
+++ b/src/align_genotype/jobs/genotype.py
@@ -9,7 +9,6 @@ from cpg_flow import filetypes, resources, utils
 from cpg_utils import Path, config, hail_batch
 from hailtop.batch.job import BashJob
 
-
 GLOBAL_INTERVALS: list[hb.ResourceFile] | None = None
 
 
@@ -58,7 +57,7 @@ def genotype(
     return jobs
 
 
-def haplotype_caller(  # noqa: PLR0913
+def haplotype_caller(
     sequencing_group_name: str,
     cram_path: str,
     tmp_prefix: Path,

--- a/src/align_genotype/jobs/multiqc.py
+++ b/src/align_genotype/jobs/multiqc.py
@@ -8,7 +8,7 @@ from hailtop.batch import Batch, ResourceFile
 from hailtop.batch.job import Job
 
 
-def multiqc(  # noqa: PLR0913
+def multiqc(
     dataset: targets.Dataset,
     tmp_prefix: Path,
     paths: list[Path],
@@ -110,7 +110,7 @@ def multiqc(  # noqa: PLR0913
     return jobs
 
 
-def check_report_job(  # noqa: PLR0913
+def check_report_job(
     b: Batch,
     multiqc_json_file: ResourceFile,
     dataset_name: str,

--- a/src/align_genotype/jobs/picard.py
+++ b/src/align_genotype/jobs/picard.py
@@ -3,7 +3,7 @@ Create Hail Batch jobs to run Picard tools (marking duplicates, QC).
 """
 
 import hailtop.batch as hb
-from cpg_flow import resources, utils
+from cpg_flow import resources
 from cpg_utils import Path, config, hail_batch
 from hailtop.batch.job import BashJob
 

--- a/src/align_genotype/jobs/picard.py
+++ b/src/align_genotype/jobs/picard.py
@@ -143,7 +143,7 @@ def generate_intervals(output_paths: list[Path], job_attrs: dict[str, str]) -> B
     -OUTPUT $BATCH_TMPDIR/out
     """
 
-    for idx in range(len(output_paths)):
+    for idx in range(scatter_count):
         name = f'temp_{str(idx + 1).zfill(4)}_of_{scatter_count}'
         cmd += f"""
         ln $BATCH_TMPDIR/out/{name}/scattered.interval_list {job[f'{idx + 1}.interval_list']}
@@ -151,7 +151,7 @@ def generate_intervals(output_paths: list[Path], job_attrs: dict[str, str]) -> B
 
     job.command(cmd)
 
-    for idx in range(len(output_paths)):
+    for idx in range(scatter_count):
         batch_instance.write_output(job[f'{idx + 1}.interval_list'], output_paths[idx])
 
     return job

--- a/src/align_genotype/stages.py
+++ b/src/align_genotype/stages.py
@@ -13,19 +13,19 @@ from align_genotype.jobs.cram_qc_samtools import samtools_stats
 from align_genotype.jobs.cram_qc_somalier import extract_somalier
 from align_genotype.jobs.cram_qc_verify import verifybamid
 from align_genotype.jobs.genotype import genotype
-from align_genotype.jobs.picard import collect_metrics, hs_metrics, vcf_qc, wgs_metrics, generate_intervals
+from align_genotype.jobs.picard import collect_metrics, generate_intervals, hs_metrics, vcf_qc, wgs_metrics
 
 
 @stage.stage
 class GenerateIntervalsOnce(stage.MultiCohortStage):
-    def expected_outputs(self, multicohort: MultiCohort) -> dict[str, list[Path]]:
+    def expected_outputs(self, multicohort: MultiCohort) -> dict[str, list[Path]]:  # noqa: ARG002
         scatter_count = config.config_retrieve(['workflow', 'scatter_count_genotype'])
         return {'intervals': [to_path(f'{idx}.interval_list') for idx in range(1, scatter_count + 1)]}
 
     def queue_jobs(
         self,
         multicohort: MultiCohort,
-        inputs: StageInput,
+        inputs: StageInput,  # noqa: ARG002
     ) -> StageOutput:
         outputs = self.expected_outputs(multicohort)
         job = generate_intervals(outputs['intervals'], self.get_job_attrs(multicohort))


### PR DESCRIPTION
# Purpose

  - The generation of intervals for haplotypecaller is arbitrarily done using the first SG to be processed. This means that there is a DAG dependency on this first sample's alignment job. If that sample takes ages to complete, all other SGs in the run will be delayed.
  - closes #19 

## Proposed Changes

  - Moves interval generation to a separate Stage, generating these files at the start of the workflow
  - Genotyping stage uses this output
  - Retains the `global` logic, meaning the resource group is only generated once per run. Not sure if this is really necessary, but it reduces the number of files Hail has to track/plan into the batch by 50 * SGs

## Also

 - removes a linting rule (no more than 5 args to a method), and removes the corresponding single-method noqa comments throughout the code

## Checklist

- [x] Related GitHub Issue created
- [ ] Tests covering new change
- [x] Linting checks pass
