### PR TITLE
Add gspath prefix to interval outpaths

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ on:
 permissions: {}
 
 env:
-  VERSION: 0.2.0
+  VERSION: 0.2.1
   IMAGE_NAME: cpg-flow-align-genotype
   DOCKER_DEV: australia-southeast1-docker.pkg.dev/cpg-common/images-dev
   DOCKER_MAIN: australia-southeast1-docker.pkg.dev/cpg-common/images

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This single-sample workflow has a dedicated entrypoint, and can be operated thro
 
 ```bash
 analysis-runner --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.2.0 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.2.1 \
     --config CONFIG_FILE.toml \
     --dataset seqr \
     --description 'Single-Sample data generation' \
@@ -38,7 +38,7 @@ A secondary workflow continues on from the single-sample steps, and produces Dat
 This Dataset-level workflow can be run in a similar way, but with a different entrypoint:
 ```bash
 analysis-runner --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.2.0 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.2.1 \
     --config CONFIG_FILE.toml \
     --dataset seqr \
     --description 'Dataset-Level QC workflow' \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='Dragmap align & genotype workflow, using CPG-Flow'
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.11"
-version="0.2.0"
+version="0.2.1"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -112,7 +112,7 @@ section-order = ["future", "standard-library", "third-party", "first-party", "lo
 "src/align_genotype/jobs/somalier.py" = ["C901", "PLR0912", "PLR0913", "PLR0915"]  # ignore complexity for this script
 
 [tool.bumpversion]
-current_version = "0.2.0"
+current_version = "0.2.1"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ commit_args = ""
 
 [[tool.bumpversion.files]]
 filename = "pyproject.toml"
-search = "version='{current_version}'"
+search = 'version="{current_version}"'
 replace = 'version="{new_version}"'
 
 [[tool.bumpversion.files]]

--- a/src/align_genotype/stages.py
+++ b/src/align_genotype/stages.py
@@ -15,9 +15,10 @@ from align_genotype.jobs.picard import collect_metrics, generate_intervals, hs_m
 
 @stage.stage
 class GenerateIntervalsOnce(stage.MultiCohortStage):
-    def expected_outputs(self, multicohort: targets.MultiCohort) -> dict[str, list[Path]]:  # noqa: ARG002
+    def expected_outputs(self, multicohort: targets.MultiCohort) -> dict[str, list[Path]]:
         scatter_count = config.config_retrieve(['workflow', 'scatter_count_genotype'])
-        return {'intervals': [to_path(f'{idx}.interval_list') for idx in range(1, scatter_count + 1)]}
+        prefix = multicohort.analysis_dataset.prefix(category='tmp') / 'genotype' / 'intervals'
+        return {'intervals': [prefix / to_path(f'{idx}.interval_list') for idx in range(1, scatter_count + 1)]}
 
     def queue_jobs(
         self,


### PR DESCRIPTION
Adds the GS path elements to the output paths of the new intervals stage, using the multicohort's analysis dataset (the one submitted as the analysis-runner dataset)

Without this, the path is assumed to be local and fails:
https://batch.hail.populationgenomics.org.au/batches/633553/jobs/1
