### PR TITLE
Add VNtyper stage and job

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.134.cpg2-2
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.4.8
+ENV VERSION=0.4.9
 
 WORKDIR /align_genotype
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This single-sample workflow has a dedicated entrypoint, and can be operated thro
 
 ```bash
 analysis-runner --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.4.8-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.4.9-1 \
     --config CONFIG_FILE.toml \
     --dataset seqr \
     --description 'Single-Sample data generation' \
@@ -38,7 +38,7 @@ A secondary workflow continues on from the single-sample steps, and produces Dat
 This Dataset-level workflow can be run in a similar way, but with a different entrypoint:
 ```bash
 analysis-runner --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.4.8-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.4.9-1 \
     --config CONFIG_FILE.toml \
     --dataset seqr \
     --description 'Dataset-Level QC workflow' \

--- a/README.md
+++ b/README.md
@@ -2,50 +2,62 @@
 
 A [CPG-Flow](https://github.com/populationgenomics/cpg-flow) migration of the Alignment and Genotyping workflow from Production Pipelines.
 
-Alignment: https://github.com/populationgenomics/production-pipelines/blob/ca8741c9d34c85f3f3e0811f081e67d56086d831/cpg_workflows/stages/align.py
+These workflows start with the single-sample assay data we've received from our collaborators, FastQ, BAM, or FQ.ora, and carry out the alignment and genotyping steps of the analysis, including:
 
-Genotyping: https://github.com/populationgenomics/production-pipelines/blob/ca8741c9d34c85f3f3e0811f081e67d56086d831/cpg_workflows/stages/genotype.py
-
-Cram QC: https://github.com/populationgenomics/production-pipelines/blob/main/cpg_workflows/stages/cram_qc.py
-
-gVCF QC: https://github.com/populationgenomics/production-pipelines/blob/main/cpg_workflows/stages/gvcf_qc.py
-
-These workflows start with the single-sample assay data we've received from our collaborators, FastQ, BAM, or FQ.ora,
-and carry out the alignment and genotyping steps of the analysis, including:
 - Aligning the reads to the reference genome using DRAGMAP (Dragen-OS)
 - Generating alignment quality metrics using Samtools, Picard, and Somalier fingerprinting
 - Genotyping the aligned reads using GATK HaplotypeCaller
 - Generating gVCF quality metrics using Picard
+- Running VerifyBamID to check for contamination and sample swaps
+- Running VNtyper to genotype the VNTR regions of the genome
+
+## Running the workflows
 
 This single-sample workflow has a dedicated entrypoint, and can be operated through analysis runner as follows:
 
 ```bash
 analysis-runner --skip-repo-checkout \
     --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.4.9-1 \
-    --config CONFIG_FILE.toml \
+    --config src/align_genotype/config_template.toml \
     --dataset seqr \
     --description 'Single-Sample data generation' \
     --access-level full \
     --output-dir OUTPUT_DIR \
     run_workflow
-````
+```
 
 A secondary workflow continues on from the single-sample steps, and produces Dataset-level outputs, including:
+
 - Runs Somalier Relate on the Dataset's Somalier fingerprints to generate a Dataset-level pedigree
 - Uses the somalier outputs to check relationships against the expected pedigree
 - Runs Dataset-level MultiQC for the CRAM and gVCF metrics, publishing an HTML report, and writing the results to Slack
 
 This Dataset-level workflow can be run in a similar way, but with a different entrypoint:
+
 ```bash
 analysis-runner --skip-repo-checkout \
     --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.4.9-1 \
-    --config CONFIG_FILE.toml \
+    --config src/align_genotype/config_template.toml \
     --dataset seqr \
     --description 'Dataset-Level QC workflow' \
     --access-level full \
     --output-dir OUTPUT_DIR \
     dataset_workflow
-````
+```
+
+A third workflow is available to run VNtyper on a set of samples, which can be used to genotype the VNTR regions of the genome. This workflow requires the Align stage to have completed and can be run with the following command:
+
+```bash
+analysis-runner --skip-repo-checkout \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.4.9-1 \
+    --config src/align_genotype/config_template.toml \
+    --config src/align_genotype/vntyper.toml \
+    --dataset seqr \
+    --description 'VNtyper workflow' \
+    --access-level full \
+    --output-dir OUTPUT_DIR \
+    run_workflow
+```
 
 ## Configuration
 
@@ -55,6 +67,8 @@ Two entries in the config template should be modified for each run:
 
 - `workflow.input_cohorts`:  a list of Cohort IDs to be used as input
 - `workflow.sequencing_type`: 'exome' or 'genome', depending on the type of sequencing data being processed
+
+A secondary config file is provided for the VNtyper workflow, which contains settings specific to only this stage. Without this config, the stage is always skipped. It should be last in the config list when running the workflow, so that it can override any relevant settings in the main config template.
 
 ## Structure
 
@@ -84,3 +98,12 @@ src
 │   ├── stages.py
 │   └── utils.py
 ```
+
+## Original code
+
+The original code for the alignment and genotyping workflow can be found in the Production Pipelines repository, in the following files:
+
+- [Alignment](https://github.com/populationgenomics/production-pipelines/blob/ca8741c9d34c85f3f3e0811f081e67d56086d831/cpg_workflows/stages/align.py)
+- [Genotyping](https://github.com/populationgenomics/production-pipelines/blob/ca8741c9d34c85f3f3e0811f081e67d56086d831/cpg_workflows/stages/genotype.py)
+- [Cram QC](https://github.com/populationgenomics/production-pipelines/blob/main/cpg_workflows/stages/cram_qc.py)
+- [gVCF QC](https://github.com/populationgenomics/production-pipelines/blob/main/cpg_workflows/stages/gvcf_qc.py)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='Dragmap align & genotype workflow, using CPG-Flow'
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.11"
-version="0.4.8"
+version="0.4.9"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -99,7 +99,7 @@ section-order = ["future", "standard-library", "third-party", "first-party", "lo
 "src/align_genotype/jobs/somalier.py" = ["C901", "PLR0912", "PLR0913", "PLR0915"]  # ignore complexity for this script
 
 [tool.bumpversion]
-current_version = "0.4.8"
+current_version = "0.4.9"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/align_genotype/config_template.toml
+++ b/src/align_genotype/config_template.toml
@@ -103,6 +103,7 @@ picard = "australia-southeast1-docker.pkg.dev/cpg-common/images/picard:3.4.0-3"
 samtools = "australia-southeast1-docker.pkg.dev/cpg-common/images/samtools:1.18"
 somalier = "australia-southeast1-docker.pkg.dev/cpg-common/images/somalier:0.3.1-1"
 verifybamid = "australia-southeast1-docker.pkg.dev/cpg-common/images/verifybamid:2.0.1"
+vntyper = "australia-southeast1-docker.pkg.dev/cpg-common/images/vntyper:2.0.3-2"
 
 [references]
 dragmap_prefix = "gs://cpg-common-main/references/hg38/v0/dragen_reference"

--- a/src/align_genotype/config_template.toml
+++ b/src/align_genotype/config_template.toml
@@ -123,6 +123,8 @@ hg38_telomeres_and_centromeres_intervals_list = "gs://cpg-common-main/references
 somalier_sites = "gs://cpg-common-main/references/somalier/sites.hg38.vcf.gz"
 dbsnp_vcf = "gs://cpg-common-main/references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf"
 
-# [vntyper]
-# log_level = "DEBUG"
+[vntyper]
+# Logs are very slim when set to INFO
+log_level = "DEBUG"
+# gs:// path to a config that overrides the VNtyper default
 # config_json_path = ""

--- a/src/align_genotype/config_template.toml
+++ b/src/align_genotype/config_template.toml
@@ -1,4 +1,8 @@
 [workflow]
+
+# use the vntyper.toml config for this stage
+skip_stages = ['VNtyper',]
+
 # set this to false if we want to use non-preemptible machines
 align_spot = true
 
@@ -103,7 +107,6 @@ picard = "australia-southeast1-docker.pkg.dev/cpg-common/images/picard:3.4.0-3"
 samtools = "australia-southeast1-docker.pkg.dev/cpg-common/images/samtools:1.18"
 somalier = "australia-southeast1-docker.pkg.dev/cpg-common/images/somalier:0.3.1-1"
 verifybamid = "australia-southeast1-docker.pkg.dev/cpg-common/images/verifybamid:2.0.1"
-vntyper = "australia-southeast1-docker.pkg.dev/cpg-common/images/vntyper:2.0.3-2"
 
 [references]
 dragmap_prefix = "gs://cpg-common-main/references/hg38/v0/dragen_reference"

--- a/src/align_genotype/config_template.toml
+++ b/src/align_genotype/config_template.toml
@@ -121,3 +121,7 @@ exome_calling_interval_lists = "gs://cpg-common-main/references/hg38/v0/exome_ca
 hg38_telomeres_and_centromeres_intervals_list = "gs://cpg-common-main/references/hg38/v0/hg38.telomeres_centromeres_and_hard_calling_exclusions.interval_list"
 somalier_sites = "gs://cpg-common-main/references/somalier/sites.hg38.vcf.gz"
 dbsnp_vcf = "gs://cpg-common-main/references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf"
+
+# [vntyper]
+# log_level = "DEBUG"
+# config_json_path = ""

--- a/src/align_genotype/config_template.toml
+++ b/src/align_genotype/config_template.toml
@@ -122,9 +122,3 @@ exome_calling_interval_lists = "gs://cpg-common-main/references/hg38/v0/exome_ca
 hg38_telomeres_and_centromeres_intervals_list = "gs://cpg-common-main/references/hg38/v0/hg38.telomeres_centromeres_and_hard_calling_exclusions.interval_list"
 somalier_sites = "gs://cpg-common-main/references/somalier/sites.hg38.vcf.gz"
 dbsnp_vcf = "gs://cpg-common-main/references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf"
-
-[vntyper]
-# Logs are very slim when set to INFO
-log_level = "DEBUG"
-# gs:// path to a config that overrides the VNtyper default
-# config_json_path = ""

--- a/src/align_genotype/jobs/vntyper.py
+++ b/src/align_genotype/jobs/vntyper.py
@@ -69,7 +69,7 @@ def vntyper(
     cram_resource_group = batch_instance.read_input_group(**{'cram': cram_path, 'cram.crai': f'{cram_path!s}.crai'})
 
     job.command(f"""\
-    export REF_PATH={reference['base']} && \
+    export CRAM_REFERENCE={reference['base']} && \
 
     vntyper pipeline \
         --cram {cram_resource_group.cram} \

--- a/src/align_genotype/jobs/vntyper.py
+++ b/src/align_genotype/jobs/vntyper.py
@@ -35,7 +35,7 @@ results/
 ├── coverage/
 │   └── coverage_summary.tsv     # VNTR region coverage statistics
 └── advntr/                      # Only when --extra-modules advntr
-    ├── output_adVNTR.tsv         # Raw adVNTR output
+    ├── output_adVNTR.vcf         # Raw adVNTR output
     ├── output_adVNTR_result.tsv  # Processed adVNTR result
     └── cross_match_results.tsv   # Kestrel vs adVNTR comparison
 """

--- a/src/align_genotype/jobs/vntyper.py
+++ b/src/align_genotype/jobs/vntyper.py
@@ -73,9 +73,12 @@ def vntyper(
     echo "Using reference: $CRAM_REFERENCE"
     """)
 
-    vntyper_command_prefix = 'vntyper '
+    vntyper_command_prefix = 'vntyper'
     if log_level := config.config_retrieve(['workflow', 'vntyper_log_level'], None):
-        vntyper_command_prefix += f' --log-level {log_level} '
+        vntyper_command_prefix += f' --log-level {log_level}'
+    if vntyper_config_path := config.config_retrieve(['workflow', 'vntyper_config_path']):
+        vntyper_config = batch_instance.read_input(vntyper_config_path)
+        vntyper_command_prefix += f' --config {vntyper_config}'
     vntyper_command_str = f"""\
     {vntyper_command_prefix} pipeline \
         --cram {cram_resource_group.cram} \
@@ -83,44 +86,16 @@ def vntyper(
         --extra-modules advntr \
         -o ./results \
         --threads 4"""
-    # Optional config override
-    if vntyper_config_path := config.config_retrieve(['workflow', 'vntyper_config_path']):
-        vntyper_config = batch_instance.read_input(vntyper_config_path)
-        vntyper_command_str += f' --config {vntyper_config}'
 
     job.command(vntyper_command_str)
-
-    if config.config_retrieve(['workflow', 'print_sort_fastq_log'], False):
-        sort_fastq_log_path = 'results/fastq_bam_processing/output_sort_fastq.log'
-        job.command(f"""\
-        # Check if sort_fastq log file exists and print its contents for debugging
-        if [ -f {sort_fastq_log_path} ]; then \
-            echo "sort_fastq log file found: {sort_fastq_log_path}" && \
-            cat {sort_fastq_log_path}; \
-        else \
-            echo "sort_fastq log file not found: {sort_fastq_log_path}"; \
-        fi
-        """)
-
-    if config.config_retrieve(['workflow', 'print_kestrel_log'], False):
-        kestrel_log_path = 'results/kestrel/kestrel_kmer_20.log'
-        job.command(f"""\
-        # Check if Kestrel log file exists and print its contents for debugging
-        if [ -f {kestrel_log_path} ]; then \
-            echo "Kestrel log file found: {kestrel_log_path}" && \
-            cat {kestrel_log_path}; \
-        else \
-            echo "Kestrel log file not found: {kestrel_log_path}"; \
-        fi
-        """)
 
     job.command(f"""\
         mv ./results/summary_report.html {job.html} && \
         mv ./results/kestrel/kestrel_result.tsv {job.kestrel} && \
         mv ./results/kestrel/kestrel_pre_result.tsv {job.kestrel_pre} && \
         mv ./results/kestrel/output.vcf {job.kestrel_vcf} && \
-        mv ./results/advntr/output_adVNTR.vcf {job.advntr} && \
-        mv ./results/advntr/output_adVNTR_result.vcf {job.advntr_result} && \
+        mv ./results/advntr/output_adVNTR.tsv {job.advntr} && \
+        mv ./results/advntr/output_adVNTR_result.tsv {job.advntr_result} && \
         mv ./results/advntr/cross_match_results.tsv {job.cross_match}
     """)
 

--- a/src/align_genotype/jobs/vntyper.py
+++ b/src/align_genotype/jobs/vntyper.py
@@ -71,21 +71,19 @@ def vntyper(
     #Require CRAM_REFERENCE env var for VNtyper to find the reference FASTA
     export CRAM_REFERENCE={reference['base']} && \
     echo "Using reference: $CRAM_REFERENCE"
-    """
-    )
+    """)
     vntyper_command_str = f"""\
     vntyper pipeline \
         --cram {cram_resource_group.cram} \
         --reference-assembly hg38 \
         -o ./results \
-        --threads 4
-    """
+        --threads 4"""
     # Optional config override
     if vntyper_config_path := config.config_retrieve(['workflow', 'vntyper_config_path']):
         vntyper_config = batch_instance.read_input(vntyper_config_path)
-        vntyper_command_str += f" --config {vntyper_config}"
+        vntyper_command_str += f' --config {vntyper_config}'
     if log_level := config.config_retrieve(['workflow', 'vntyper_log_level']):
-        vntyper_command_str += f" --log-level {log_level}"
+        vntyper_command_str += f' --log-level {log_level}'
 
     job.command(vntyper_command_str)
 
@@ -115,10 +113,14 @@ def vntyper(
 
     job.command(f"""\
         mv ./results/summary_report.html {job.html} && \
-        mv ./results/kestrel/kestrel_result.tsv {job.kestrel}
+        mv ./results/kestrel/kestrel_result.tsv {job.kestrel} && \
+        mv ./results/kestrel/kestrel_pre_result.tsv {job.kestrel_pre} && \
+        mv ./results/kestrel/output.vcf {job.kestrel_vcf}
     """)
 
     batch_instance.write_output(job.html, str(out_paths['html']))
     batch_instance.write_output(job.kestrel, str(out_paths['kestrel']))
+    batch_instance.write_output(job.kestrel_pre, str(out_paths['kestrel_pre_filter']))
+    batch_instance.write_output(job.kestrel_vcf, str(out_paths['kestrel_raw_vcf']))
 
     return job

--- a/src/align_genotype/jobs/vntyper.py
+++ b/src/align_genotype/jobs/vntyper.py
@@ -69,7 +69,7 @@ def vntyper(
     cram_resource_group = batch_instance.read_input_group(**{'cram': cram_path, 'cram.crai': f'{cram_path!s}.crai'})
 
     job.command(f"""\
-    export HTS_REF_PATH={reference['base']} && \
+    export CRAM_REFERENCE={reference['base']} && \
 
     vntyper pipeline \
         --cram {cram_resource_group.cram} \

--- a/src/align_genotype/jobs/vntyper.py
+++ b/src/align_genotype/jobs/vntyper.py
@@ -82,8 +82,8 @@ def vntyper(
     """
     # Optional config override
     if vntyper_config_path := config.config_retrieve(['workflow', 'vntyper_config_path']):
-        config = batch_instance.read_input(vntyper_config_path)
-        vntyper_command_str += f" --config {config}"
+        vntyper_config = batch_instance.read_input(vntyper_config_path)
+        vntyper_command_str += f" --config {vntyper_config}"
     if log_level := config.config_retrieve(['workflow', 'vntyper_log_level']):
         vntyper_command_str += f" --log-level {log_level}"
 

--- a/src/align_genotype/jobs/vntyper.py
+++ b/src/align_genotype/jobs/vntyper.py
@@ -65,29 +65,41 @@ def vntyper(
     job_res.set_to_job(job)
 
     reference = hail_batch.fasta_res_group(batch_instance)
-
     cram_resource_group = batch_instance.read_input_group(**{'cram': cram_path, 'cram.crai': f'{cram_path!s}.crai'})
 
-    config_path = '/usr/local/lib/python3.11/site-packages/vntyper/config.json'
     job.command(f"""\
     #Require CRAM_REFERENCE env var for VNtyper to find the reference FASTA
     export CRAM_REFERENCE={reference['base']} && \
     echo "Using reference: $CRAM_REFERENCE" && \
-
-    echo "Original vntyper config:" && cat {config_path} && \
-    #Update vntyper config to set cli_defaults.log_level to "DEBUG" for more verbose logging
-    sed -i 's/"log_level": "INFO"/"log_level": "DEBUG"/' {config_path} && \
-    echo "Updated vntyper config:" && cat {config_path}
     """
     )
-
-    job.command(f"""\
+    vntyper_command_str = f"""\
     vntyper pipeline \
         --cram {cram_resource_group.cram} \
         --reference-assembly hg38 \
         -o ./results \
         --threads 4
-    """)
+    """
+    # Optional config override
+    if vntyper_config_path := config.config_retrieve(['workflow', 'vntyper_config_path']):
+        config = batch_instance.read_input(vntyper_config_path)
+        vntyper_command_str += f" --config {config}"
+    if log_level := config.config_retrieve(['workflow', 'vntyper_log_level']):
+        vntyper_command_str += f" --log-level {log_level}"
+
+    job.command(vntyper_command_str)
+
+    if config.config_retrieve(['workflow', 'print_kestrel_log'], False):
+        kestrel_log_path = 'results/kestrel/kestrel_kmer_20.log'
+        job.command(f"""\
+        # Check if Kestrel log file exists and print its contents for debugging
+        if [ -f {kestrel_log_path} ]; then \
+            echo "Kestrel log file found: {kestrel_log_path}" && \
+            cat {kestrel_log_path}; \
+        else \
+            echo "Kestrel log file not found: {kestrel_log_path}"; \
+        fi
+        """)
 
     job.command(f"""\
         mv ./results/summary_report.html {job.html} && \

--- a/src/align_genotype/jobs/vntyper.py
+++ b/src/align_genotype/jobs/vntyper.py
@@ -119,8 +119,8 @@ def vntyper(
         mv ./results/kestrel/kestrel_result.tsv {job.kestrel} && \
         mv ./results/kestrel/kestrel_pre_result.tsv {job.kestrel_pre} && \
         mv ./results/kestrel/output.vcf {job.kestrel_vcf} && \
-        mv ./results/advntr/output_adVNTR.tsv {job.advntr} && \
-        mv ./results/advntr/output_adVNTR_result.tsv {job.advntr_result} && \
+        mv ./results/advntr/output_adVNTR.vcf {job.advntr} && \
+        mv ./results/advntr/output_adVNTR_result.vcf {job.advntr_result} && \
         mv ./results/advntr/cross_match_results.tsv {job.cross_match}
     """)
 

--- a/src/align_genotype/jobs/vntyper.py
+++ b/src/align_genotype/jobs/vntyper.py
@@ -75,7 +75,6 @@ def vntyper(
     vntyper pipeline \
         --cram {cram_resource_group.cram} \
         --reference-assembly hg38 \
-        -ref ./references \
         -o ./results \
         --threads 4
     """)

--- a/src/align_genotype/jobs/vntyper.py
+++ b/src/align_genotype/jobs/vntyper.py
@@ -70,7 +70,7 @@ def vntyper(
     job.command(f"""\
     #Require CRAM_REFERENCE env var for VNtyper to find the reference FASTA
     export CRAM_REFERENCE={reference['base']} && \
-    echo "Using reference: $CRAM_REFERENCE" && \
+    echo "Using reference: $CRAM_REFERENCE"
     """
     )
     vntyper_command_str = f"""\

--- a/src/align_genotype/jobs/vntyper.py
+++ b/src/align_genotype/jobs/vntyper.py
@@ -94,7 +94,7 @@ def vntyper(
         mv ./results/kestrel/kestrel_result.tsv {job.kestrel} && \
         mv ./results/kestrel/kestrel_pre_result.tsv {job.kestrel_pre} && \
         mv ./results/kestrel/output.vcf {job.kestrel_vcf} && \
-        mv ./results/advntr/output_adVNTR.tsv {job.advntr} && \
+        mv ./results/advntr/output_adVNTR.vcf {job.advntr} && \
         mv ./results/advntr/output_adVNTR_result.tsv {job.advntr_result} && \
         mv ./results/advntr/cross_match_results.tsv {job.cross_match}
     """)

--- a/src/align_genotype/jobs/vntyper.py
+++ b/src/align_genotype/jobs/vntyper.py
@@ -2,7 +2,6 @@
 CRAM to VNtyper results: create Hail Batch jobs to run VNtyper on individual sequencing groups.
 """
 
-import hailtop.batch as hb
 from cpg_flow import resources
 from cpg_utils import Path, config, hail_batch
 from hailtop.batch.job import BashJob
@@ -46,7 +45,7 @@ def vntyper(
     cram_path: str,
     out_paths: dict[str, Path],
     job_attrs: dict[str, str],
-) -> tuple[BashJob | None, hb.Resource]:
+) -> BashJob:
     """
     Add one VNtyper job.
     """
@@ -87,4 +86,4 @@ def vntyper(
     batch_instance.write_output(job.html, str(out_paths['html']))
     batch_instance.write_output(job.kestrel, str(out_paths['kestrel']))
 
-    return job, job.output_files
+    return job

--- a/src/align_genotype/jobs/vntyper.py
+++ b/src/align_genotype/jobs/vntyper.py
@@ -72,8 +72,12 @@ def vntyper(
     export CRAM_REFERENCE={reference['base']} && \
     echo "Using reference: $CRAM_REFERENCE"
     """)
+
+    vntyper_command_prefix = 'vntyper '
+    if log_level := config.config_retrieve(['workflow', 'vntyper_log_level'], None):
+        vntyper_command_prefix += f' --log-level {log_level} '
     vntyper_command_str = f"""\
-    vntyper pipeline \
+    {vntyper_command_prefix} pipeline \
         --cram {cram_resource_group.cram} \
         --reference-assembly hg38 \
         --extra-modules advntr \

--- a/src/align_genotype/jobs/vntyper.py
+++ b/src/align_genotype/jobs/vntyper.py
@@ -76,6 +76,7 @@ def vntyper(
     vntyper pipeline \
         --cram {cram_resource_group.cram} \
         --reference-assembly hg38 \
+        --extra-modules advntr \
         -o ./results \
         --threads 4"""
     # Optional config override
@@ -113,12 +114,18 @@ def vntyper(
         mv ./results/summary_report.html {job.html} && \
         mv ./results/kestrel/kestrel_result.tsv {job.kestrel} && \
         mv ./results/kestrel/kestrel_pre_result.tsv {job.kestrel_pre} && \
-        mv ./results/kestrel/output.vcf {job.kestrel_vcf}
+        mv ./results/kestrel/output.vcf {job.kestrel_vcf} && \
+        mv ./results/advntr/output_adVNTR.tsv {job.advntr} && \
+        mv ./results/advntr/output_adVNTR_result.tsv {job.advntr_result} && \
+        mv ./results/advntr/cross_match_results.tsv {job.cross_match}
     """)
 
     batch_instance.write_output(job.html, str(out_paths['html']))
     batch_instance.write_output(job.kestrel, str(out_paths['kestrel']))
     batch_instance.write_output(job.kestrel_pre, str(out_paths['kestrel_pre_filter']))
     batch_instance.write_output(job.kestrel_vcf, str(out_paths['kestrel_raw_vcf']))
+    batch_instance.write_output(job.advntr, str(out_paths['advntr']))
+    batch_instance.write_output(job.advntr_result, str(out_paths['advntr_result']))
+    batch_instance.write_output(job.cross_match, str(out_paths['cross_match']))
 
     return job

--- a/src/align_genotype/jobs/vntyper.py
+++ b/src/align_genotype/jobs/vntyper.py
@@ -83,7 +83,7 @@ def vntyper(
         vntyper_config = batch_instance.read_input(vntyper_config_path)
         vntyper_command_str += f' --config {vntyper_config}'
     if log_level := config.config_retrieve(['workflow', 'vntyper_log_level']):
-        vntyper_command_str += f' --log-level {log_level}'
+        vntyper_command_str += f' -l {log_level}'
 
     job.command(vntyper_command_str)
 

--- a/src/align_genotype/jobs/vntyper.py
+++ b/src/align_genotype/jobs/vntyper.py
@@ -5,6 +5,7 @@ CRAM to VNtyper results: create Hail Batch jobs to run VNtyper on individual seq
 from cpg_flow import resources
 from cpg_utils import Path, config, hail_batch
 from hailtop.batch.job import BashJob
+from loguru import logger
 
 """
 Possible outputs:
@@ -73,12 +74,18 @@ def vntyper(
     echo "Using reference: $CRAM_REFERENCE"
     """)
 
+    # construct the VNtyper command with optional config / logging parameters
     vntyper_command_prefix = 'vntyper'
-    if log_level := config.config_retrieve(['workflow', 'vntyper_log_level'], None):
+
+    if log_level := config.config_retrieve(['vntyper', 'log_level']):
+        logger.info(f'Setting log level: {log_level}')
         vntyper_command_prefix += f' --log-level {log_level}'
-    if vntyper_config_path := config.config_retrieve(['workflow', 'vntyper_config_path']):
+
+    if vntyper_config_path := config.config_retrieve(['vntyper', 'config_json_path']):
+        logger.info(f'Using config json from {vntyper_config_path}, overrides default ./vntyper/config.json')
         vntyper_config = batch_instance.read_input(vntyper_config_path)
         vntyper_command_prefix += f' --config {vntyper_config}'
+
     vntyper_command_str = f"""\
     {vntyper_command_prefix} pipeline \
         --cram {cram_resource_group.cram} \

--- a/src/align_genotype/jobs/vntyper.py
+++ b/src/align_genotype/jobs/vntyper.py
@@ -70,7 +70,7 @@ def vntyper(
     cram_resource_group = batch_instance.read_input_group(**{'cram': cram_path, 'cram.crai': f'{cram_path!s}.crai'})
 
     job.command(f"""\
-    export REF_PATH={reference['fasta']} && \
+    export REF_PATH={reference['base']} && \
 
     vntyper pipeline \
         --cram {cram_resource_group.cram} \

--- a/src/align_genotype/jobs/vntyper.py
+++ b/src/align_genotype/jobs/vntyper.py
@@ -82,8 +82,6 @@ def vntyper(
     if vntyper_config_path := config.config_retrieve(['workflow', 'vntyper_config_path']):
         vntyper_config = batch_instance.read_input(vntyper_config_path)
         vntyper_command_str += f' --config {vntyper_config}'
-    if log_level := config.config_retrieve(['workflow', 'vntyper_log_level']):
-        vntyper_command_str += f' -l {log_level}'
 
     job.command(vntyper_command_str)
 

--- a/src/align_genotype/jobs/vntyper.py
+++ b/src/align_genotype/jobs/vntyper.py
@@ -1,0 +1,91 @@
+"""
+CRAM to VNtyper results: create Hail Batch jobs to run VNtyper on individual sequencing groups.
+"""
+
+import hailtop.batch as hb
+from cpg_flow import resources
+from cpg_utils import Path, config, hail_batch
+from hailtop.batch.job import BashJob
+
+"""
+Possible outputs:
+
+results/
+├── pipeline_summary.json        # Machine-readable pipeline summary
+├── pipeline_summary.csv         # Optional (--summary-formats csv)
+├── pipeline_summary.tsv         # Optional (--summary-formats tsv)
+├── pipeline.log                 # Pipeline execution log
+├── summary_report.html          # HTML report with IGV visualization
+├── predefined_regions_<assembly>.bed  # Region BED file (e.g., hg19, hg38)
+├── kestrel/
+│   ├── kestrel_result.tsv       # Final genotyping result
+│   ├── kestrel_pre_result.tsv   # Pre-filter variants (all candidates)
+│   ├── output.vcf               # Raw Kestrel VCF
+│   ├── output_indel.vcf         # Filtered INDEL VCF
+│   ├── output_indel.vcf.gz      # Compressed INDEL VCF (if bcftools available)
+│   ├── output.bam               # Kestrel alignment BAM
+│   ├── output.bam.bai           # BAM index
+│   └── output.bed               # BED file for coverage visualization
+├── fastq_bam_processing/
+│   ├── output_R1.fastq.gz       # Extracted/processed R1 reads
+│   ├── output_R2.fastq.gz       # Extracted/processed R2 reads
+│   └── pipeline_info.json       # BAM header metadata (BAM/CRAM input)
+├── alignment_processing/
+│   └── output_sorted.bam        # BWA-aligned BAM (FASTQ input only)
+├── coverage/
+│   └── coverage_summary.tsv     # VNTR region coverage statistics
+└── advntr/                      # Only when --extra-modules advntr
+    ├── output_adVNTR.tsv         # Raw adVNTR output
+    ├── output_adVNTR_result.tsv  # Processed adVNTR result
+    └── cross_match_results.tsv   # Kestrel vs adVNTR comparison
+"""
+
+
+def vntyper(
+    sequencing_group_name: str,
+    cram_path: str,
+    out_paths: dict[str, Path],
+    job_attrs: dict[str, str],
+) -> tuple[BashJob | None, hb.Resource]:
+    """
+    Add one VNtyper job.
+    """
+
+    batch_instance = hail_batch.get_batch()
+
+    sequencing_type = config.config_retrieve(['workflow', 'sequencing_type'])
+    job = batch_instance.new_bash_job(f'VNtyper {sequencing_group_name}', job_attrs | {'tool': 'vntyper'})
+    job.image(config.config_retrieve(['images', 'vntyper']))
+
+    storage_default = 40 if sequencing_type == 'genome' else None
+
+    job_res = resources.HIGHMEM.request_resources(
+        ncpu=config.config_retrieve(['workflow', 'vntyper_cpu'], 4),
+        storage_gb=config.config_retrieve(['workflow', 'vntyper_storage'], storage_default),
+    )
+    job_res.set_to_job(job)
+
+    reference = hail_batch.fasta_res_group(batch_instance)
+
+    cram_resource_group = batch_instance.read_input_group(**{'cram': cram_path, 'cram.crai': f'{cram_path!s}.crai'})
+
+    job.command(f"""\
+    export REF_PATH={reference['fasta']} && \
+
+    vntyper pipeline \
+        --cram {cram_resource_group.cram} \
+        --reference-assembly hg38 \
+        -ref ./references \
+        -o ./results \
+        --threads 4
+    """)
+
+    job.command(f"""\
+        mv ./results/summary_report.html {job.html} && \
+        mv ./results/kestrel/kestrel_result.tsv {job.kestrel}
+    """)
+
+    batch_instance.write_output(job.html, str(out_paths['html']))
+    batch_instance.write_output(job.kestrel, str(out_paths['kestrel']))
+
+    return job, job.output_files

--- a/src/align_genotype/jobs/vntyper.py
+++ b/src/align_genotype/jobs/vntyper.py
@@ -89,6 +89,18 @@ def vntyper(
 
     job.command(vntyper_command_str)
 
+    if config.config_retrieve(['workflow', 'print_sort_fastq_log'], False):
+        sort_fastq_log_path = 'results/fastq_bam_processing/output_sort_fastq.log'
+        job.command(f"""\
+        # Check if sort_fastq log file exists and print its contents for debugging
+        if [ -f {sort_fastq_log_path} ]; then \
+            echo "sort_fastq log file found: {sort_fastq_log_path}" && \
+            cat {sort_fastq_log_path}; \
+        else \
+            echo "sort_fastq log file not found: {sort_fastq_log_path}"; \
+        fi
+        """)
+
     if config.config_retrieve(['workflow', 'print_kestrel_log'], False):
         kestrel_log_path = 'results/kestrel/kestrel_kmer_20.log'
         job.command(f"""\

--- a/src/align_genotype/jobs/vntyper.py
+++ b/src/align_genotype/jobs/vntyper.py
@@ -69,7 +69,7 @@ def vntyper(
     cram_resource_group = batch_instance.read_input_group(**{'cram': cram_path, 'cram.crai': f'{cram_path!s}.crai'})
 
     job.command(f"""\
-    export CRAM_REFERENCE={reference['base']} && \
+    export HTS_REF_PATH={reference['base']} && \
 
     vntyper pipeline \
         --cram {cram_resource_group.cram} \

--- a/src/align_genotype/jobs/vntyper.py
+++ b/src/align_genotype/jobs/vntyper.py
@@ -68,9 +68,20 @@ def vntyper(
 
     cram_resource_group = batch_instance.read_input_group(**{'cram': cram_path, 'cram.crai': f'{cram_path!s}.crai'})
 
+    config_path = '/usr/local/lib/python3.11/site-packages/vntyper/config.json'
     job.command(f"""\
+    #Require CRAM_REFERENCE env var for VNtyper to find the reference FASTA
     export CRAM_REFERENCE={reference['base']} && \
+    echo "Using reference: $CRAM_REFERENCE" && \
 
+    echo "Original vntyper config:" && cat {config_path} && \
+    #Update vntyper config to set cli_defaults.log_level to "DEBUG" for more verbose logging
+    sed -i 's/"log_level": "INFO"/"log_level": "DEBUG"/' {config_path} && \
+    echo "Updated vntyper config:" && cat {config_path}
+    """
+    )
+
+    job.command(f"""\
     vntyper pipeline \
         --cram {cram_resource_group.cram} \
         --reference-assembly hg38 \

--- a/src/align_genotype/run_workflow.py
+++ b/src/align_genotype/run_workflow.py
@@ -12,6 +12,7 @@ from align_genotype.stages import (
     CramQcVerifyBamId,
     GenotypeWithGatk,
     RunGvcfQc,
+    RunVntyper,
 )
 
 
@@ -31,6 +32,7 @@ def cli_main():
         CramQcSamtoolsStats,
         CramQcVerifyBamId,
         RunGvcfQc,
+        RunVntyper,
     ]
 
     run_workflow(name='align_genotype', stages=stages, dry_run=args.dry_run)

--- a/src/align_genotype/stages.py
+++ b/src/align_genotype/stages.py
@@ -304,9 +304,10 @@ class RunVntyper(stage.SequencingGroupStage):
         """
         Generate VNtyper results.
         """
+        web_path_prefix = sequencing_group.dataset.prefix(category='web') / 'vntyper'
         out_path_prefix = sequencing_group.dataset.prefix() / 'vntyper'
         return {
-            'html': out_path_prefix / f'{sequencing_group.id}_summary_report.html',
+            'html': web_path_prefix / f'{sequencing_group.id}_summary_report.html',
             'kestrel': out_path_prefix / f'{sequencing_group.id}_kestrel_result.tsv',
         }
 

--- a/src/align_genotype/stages.py
+++ b/src/align_genotype/stages.py
@@ -311,8 +311,8 @@ class RunVntyper(stage.SequencingGroupStage):
             'kestrel': out_path_prefix / f'{sequencing_group.id}_kestrel_result.tsv',
             'kestrel_pre_filter': out_path_prefix / f'{sequencing_group.id}_kestrel_pre_result.tsv',
             'kestrel_raw_vcf': out_path_prefix / f'{sequencing_group.id}_kestrel_output.vcf',
-            'advntr': out_path_prefix / f'{sequencing_group.id}_advntr_raw_result.tsv',
-            'advntr_result': out_path_prefix / f'{sequencing_group.id}_advntr_processed_result.tsv',
+            'advntr': out_path_prefix / f'{sequencing_group.id}_advntr_raw_result.vcf',
+            'advntr_result': out_path_prefix / f'{sequencing_group.id}_advntr_processed_result.vcf',
             'cross_match': out_path_prefix / f'{sequencing_group.id}_cross_match_results.tsv',
         }
 

--- a/src/align_genotype/stages.py
+++ b/src/align_genotype/stages.py
@@ -11,6 +11,7 @@ from align_genotype.jobs.cram_qc_somalier import extract_somalier
 from align_genotype.jobs.cram_qc_verify import verifybamid
 from align_genotype.jobs.genotype import genotype
 from align_genotype.jobs.picard import collect_metrics, generate_intervals, hs_metrics, vcf_qc, wgs_metrics
+from align_genotype.jobs.vntyper import vntyper
 
 
 @stage.stage
@@ -287,3 +288,41 @@ class RunGvcfQc(stage.SequencingGroupStage):
             job_attrs=self.get_job_attrs(sequencing_group),
         )
         return self.make_outputs(sequencing_group, data=outputs, jobs=job)
+
+
+@stage.stage(
+    required_stages=[AlignWithDragmap],
+    analysis_type='web',
+    analysis_keys=['html'],
+)
+class RunVntyper(stage.SequencingGroupStage):
+    """
+    Use VNtyper to genotype individual sequencing groups (i.e. CRAM -> VNtyper results).
+    """
+
+    def expected_outputs(self, sequencing_group: targets.SequencingGroup) -> dict[str, Path]:
+        """
+        Generate VNtyper results.
+        """
+        out_path_prefix = sequencing_group.dataset.prefix() / 'vntyper'
+        return {
+            'html': out_path_prefix / f'{sequencing_group.id}_summary_report.html',
+            'kestrel': out_path_prefix / f'{sequencing_group.id}_kestrel_result.tsv',
+        }
+
+    def queue_jobs(self, sequencing_group: targets.SequencingGroup, inputs: stage.StageInput) -> stage.StageOutput:
+        """
+        Queue the VNtyper job using the function from the jobs module.
+        """
+
+        outputs = self.expected_outputs(sequencing_group)
+
+        cram = inputs.as_str(sequencing_group, AlignWithDragmap, 'cram')
+
+        jobs = vntyper(
+            sequencing_group_name=sequencing_group.id,
+            cram_path=cram,
+            out_paths=outputs,
+            job_attrs=self.get_job_attrs(sequencing_group),
+        )
+        return self.make_outputs(sequencing_group, data=outputs, jobs=jobs)

--- a/src/align_genotype/stages.py
+++ b/src/align_genotype/stages.py
@@ -311,6 +311,9 @@ class RunVntyper(stage.SequencingGroupStage):
             'kestrel': out_path_prefix / f'{sequencing_group.id}_kestrel_result.tsv',
             'kestrel_pre_filter': out_path_prefix / f'{sequencing_group.id}_kestrel_pre_result.tsv',
             'kestrel_raw_vcf': out_path_prefix / f'{sequencing_group.id}_kestrel_output.vcf',
+            'advntr': out_path_prefix / f'{sequencing_group.id}_advntr_raw_result.tsv',
+            'advntr_result': out_path_prefix / f'{sequencing_group.id}_advntr_processed_result.tsv',
+            'cross_match': out_path_prefix / f'{sequencing_group.id}_cross_match_results.tsv',
         }
 
     def queue_jobs(self, sequencing_group: targets.SequencingGroup, inputs: stage.StageInput) -> stage.StageOutput:

--- a/src/align_genotype/stages.py
+++ b/src/align_genotype/stages.py
@@ -311,7 +311,7 @@ class RunVntyper(stage.SequencingGroupStage):
             'kestrel': out_path_prefix / f'{sequencing_group.id}_kestrel_result.tsv',
             'kestrel_pre_filter': out_path_prefix / f'{sequencing_group.id}_kestrel_pre_result.tsv',
             'kestrel_raw_vcf': out_path_prefix / f'{sequencing_group.id}_kestrel_output.vcf',
-            'advntr': out_path_prefix / f'{sequencing_group.id}_advntr_raw_result.tsv',
+            'advntr': out_path_prefix / f'{sequencing_group.id}_advntr_raw_result.vcf',
             'advntr_result': out_path_prefix / f'{sequencing_group.id}_advntr_processed_result.tsv',
             'cross_match': out_path_prefix / f'{sequencing_group.id}_cross_match_results.tsv',
         }

--- a/src/align_genotype/stages.py
+++ b/src/align_genotype/stages.py
@@ -309,6 +309,8 @@ class RunVntyper(stage.SequencingGroupStage):
         return {
             'html': web_path_prefix / f'{sequencing_group.id}_summary_report.html',
             'kestrel': out_path_prefix / f'{sequencing_group.id}_kestrel_result.tsv',
+            'kestrel_pre_filter': out_path_prefix / f'{sequencing_group.id}_kestrel_pre_result.tsv',
+            'kestrel_raw_vcf': out_path_prefix / f'{sequencing_group.id}_kestrel_output.vcf',
         }
 
     def queue_jobs(self, sequencing_group: targets.SequencingGroup, inputs: stage.StageInput) -> stage.StageOutput:

--- a/src/align_genotype/stages.py
+++ b/src/align_genotype/stages.py
@@ -311,8 +311,8 @@ class RunVntyper(stage.SequencingGroupStage):
             'kestrel': out_path_prefix / f'{sequencing_group.id}_kestrel_result.tsv',
             'kestrel_pre_filter': out_path_prefix / f'{sequencing_group.id}_kestrel_pre_result.tsv',
             'kestrel_raw_vcf': out_path_prefix / f'{sequencing_group.id}_kestrel_output.vcf',
-            'advntr': out_path_prefix / f'{sequencing_group.id}_advntr_raw_result.vcf',
-            'advntr_result': out_path_prefix / f'{sequencing_group.id}_advntr_processed_result.vcf',
+            'advntr': out_path_prefix / f'{sequencing_group.id}_advntr_raw_result.tsv',
+            'advntr_result': out_path_prefix / f'{sequencing_group.id}_advntr_processed_result.tsv',
             'cross_match': out_path_prefix / f'{sequencing_group.id}_cross_match_results.tsv',
         }
 

--- a/src/align_genotype/vntyper.toml
+++ b/src/align_genotype/vntyper.toml
@@ -9,3 +9,6 @@ only_stages = [
 log_level = "DEBUG"
 # gs:// path to a config that overrides the VNtyper default
 # config_json_path = ""
+
+[images]
+vntyper = "australia-southeast1-docker.pkg.dev/cpg-common/images/vntyper:2.0.3-2"

--- a/src/align_genotype/vntyper.toml
+++ b/src/align_genotype/vntyper.toml
@@ -1,0 +1,11 @@
+[workflow]
+sequencing_type = 'genome'
+only_stages = [
+    'RunVntyper',
+]
+
+[vntyper]
+# Logs are very slim when set to INFO
+log_level = "DEBUG"
+# gs:// path to a config that overrides the VNtyper default
+# config_json_path = ""

--- a/src/align_genotype/vntyper.toml
+++ b/src/align_genotype/vntyper.toml
@@ -1,7 +1,15 @@
 [workflow]
 sequencing_type = 'genome'
+
+first_stages = []
+last_stages = []
+skip_stages = [] 
 only_stages = [
     'RunVntyper',
+]
+
+input_cohorts = [
+    # only cohorts to run VNtyper on
 ]
 
 [vntyper]

--- a/src/align_genotype/vntyper.toml
+++ b/src/align_genotype/vntyper.toml
@@ -3,7 +3,7 @@ sequencing_type = 'genome'
 
 first_stages = []
 last_stages = []
-skip_stages = [] 
+skip_stages = []
 only_stages = [
     'RunVntyper',
 ]


### PR DESCRIPTION
# Purpose

  - Add VNtyper as an optional stage in the workflow, performing Kestrel (k-mer frequency genotyping) and adVNTR genotyping

## Proposed Changes

  - New stage `VNtyper` that produces a web report analysis linked to a summary html file containing the genotyping results
  - Saves the html to the web bucket and all other relevant outputs to `main/vntyper`, with sequencing group ID prefixes on the filenames

## Checklist

- [ ] Related GitHub Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
