### PR TITLE
Add override path option for kestrel config json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg1-1
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.4.10
+ENV VERSION=0.4.11
 
 WORKDIR /align_genotype
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This single-sample workflow has a dedicated entrypoint, and can be operated thro
 
 ```bash
 analysis-runner --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.4.10-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.4.11-1 \
     --config src/align_genotype/config_template.toml \
     --dataset seqr \
     --description 'Single-Sample data generation' \
@@ -36,7 +36,7 @@ This Dataset-level workflow can be run in a similar way, but with a different en
 
 ```bash
 analysis-runner --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.4.10-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.4.11-1 \
     --config src/align_genotype/config_template.toml \
     --dataset seqr \
     --description 'Dataset-Level QC workflow' \
@@ -49,7 +49,7 @@ A third workflow is available to run VNtyper on a set of samples, which can be u
 
 ```bash
 analysis-runner --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.4.10-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.4.11-1 \
     --config src/align_genotype/config_template.toml \
     --config src/align_genotype/vntyper.toml \
     --dataset seqr \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='Dragmap align & genotype workflow, using CPG-Flow'
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.4.10"
+version="0.4.11"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -99,7 +99,7 @@ section-order = ["future", "standard-library", "third-party", "first-party", "lo
 "src/align_genotype/jobs/somalier.py" = ["C901", "PLR0912", "PLR0913", "PLR0915"]  # ignore complexity for this script
 
 [tool.bumpversion]
-current_version = "0.4.10"
+current_version = "0.4.11"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/align_genotype/jobs/vntyper.py
+++ b/src/align_genotype/jobs/vntyper.py
@@ -81,10 +81,18 @@ def vntyper(
         logger.info(f'Setting log level: {log_level}')
         vntyper_command_prefix += f' --log-level {log_level}'
 
-    if vntyper_config_path := config.config_retrieve(['vntyper', 'config_json_path']):
+    if vntyper_config_path := config.config_retrieve(['vntyper', 'vntyper_config_json_path']):
         logger.info(f'Using config json from {vntyper_config_path}, overrides default ./vntyper/config.json')
         vntyper_config = batch_instance.read_input(vntyper_config_path)
         vntyper_command_prefix += f' --config {vntyper_config}'
+
+    if kestrel_config_path := config.config_retrieve(['vntyper', 'kestrel_config_json_path']):
+        logger.info(
+            f'Using Kestrel config json from {kestrel_config_path}, '
+            f'overrides default ./vntyper/scripts/kestrel_config.json'
+        )
+        kestrel_config = batch_instance.read_input(kestrel_config_path)
+        job.command(f'cp {kestrel_config} ./vntyper/scripts/kestrel_config.json')
 
     vntyper_command_str = f"""\
     {vntyper_command_prefix} pipeline \

--- a/src/align_genotype/vntyper.toml
+++ b/src/align_genotype/vntyper.toml
@@ -8,15 +8,12 @@ only_stages = [
     'RunVntyper',
 ]
 
-input_cohorts = [
-    # only cohorts to run VNtyper on
-]
-
 [vntyper]
 # Logs are very slim when set to INFO
 log_level = "DEBUG"
-# gs:// path to a config that overrides the VNtyper default
-# config_json_path = ""
+# gs:// path to configs that override the VNtyper / kestrel defaults
+vntyper_config_json_path = false
+kestrel_config_json_path = false
 
 [images]
 vntyper = "australia-southeast1-docker.pkg.dev/cpg-common/images/vntyper:2.0.3-2"


### PR DESCRIPTION
# Purpose

  - Add an override option for the kestrel config json to allow user-set parameters, such as K-mer length for graph construction or Maximum haplotype states for genotype resolution. See the [kestrel_config.json](https://github.com/hassansaei/VNtyper/blob/4b29169983f389a9d44af767997b783729076f27/vntyper/scripts/kestrel_config.json) source file.


## Proposed Changes

  - Add a config option that reads a json filepath and uses it to overwrite the existing `kestrel_config.json` file stored at the path `./vntyper/scripts/kestrel_config.json` 
    - Although it would be nice to add simple config overrides like `kmer_length` or `max_haplotype_states` - this isn't so simple, because the VNtyper module reads the config json directly when running kestrel, with no option to override. We could implement a smart method of updating the json files based on config options, but it's equally simple to just upload an updated copy of the config json to a bucket path and point the pipeline to that as an override.

## Tests

Test run here, using k=17 in a config override file:
https://batch.hail.populationgenomics.org.au/batches/1129626/jobs/1
```
2026-05-15 00:36:19,067 - root - INFO - Launching Kestrel with k-mer size 17...
```


## Checklist

- [ ] Related GitHub Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
