### PR TITLE
Save intervals to path prefixed by seq type and scatter_count

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg1-1
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.4.12
+ENV VERSION=0.4.13
 
 WORKDIR /align_genotype
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This single-sample workflow has a dedicated entrypoint, and can be operated thro
 
 ```bash
 analysis-runner --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.4.12-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.4.13-1 \
     --config src/align_genotype/config_template.toml \
     --dataset seqr \
     --description 'Single-Sample data generation' \
@@ -36,7 +36,7 @@ This Dataset-level workflow can be run in a similar way, but with a different en
 
 ```bash
 analysis-runner --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.4.12-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.4.13-1 \
     --config src/align_genotype/config_template.toml \
     --dataset seqr \
     --description 'Dataset-Level QC workflow' \
@@ -49,7 +49,7 @@ A third workflow is available to run VNtyper on a set of samples, which can be u
 
 ```bash
 analysis-runner --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.4.12-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.4.13-1 \
     --config src/align_genotype/config_template.toml \
     --config src/align_genotype/vntyper.toml \
     --dataset seqr \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='Dragmap align & genotype workflow, using CPG-Flow'
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.4.12"
+version="0.4.13"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -99,7 +99,7 @@ section-order = ["future", "standard-library", "third-party", "first-party", "lo
 "src/align_genotype/jobs/somalier.py" = ["C901", "PLR0912", "PLR0913", "PLR0915"]  # ignore complexity for this script
 
 [tool.bumpversion]
-current_version = "0.4.12"
+current_version = "0.4.13"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/align_genotype/stages.py
+++ b/src/align_genotype/stages.py
@@ -18,7 +18,13 @@ from align_genotype.jobs.vntyper import vntyper
 class GenerateIntervalsOnce(stage.MultiCohortStage):
     def expected_outputs(self, multicohort: targets.MultiCohort) -> dict[str, list[Path]]:
         scatter_count = config.config_retrieve(['workflow', 'scatter_count_genotype'])
-        prefix = multicohort.analysis_dataset.prefix(category='tmp') / 'genotype' / 'intervals'
+        sequencing_type = config.config_retrieve(['workflow', 'sequencing_type'])
+        prefix = (
+            multicohort.analysis_dataset.prefix(category='tmp')
+            / 'genotype'
+            / sequencing_type
+            / f'{scatter_count}_intervals'
+        )
         return {'intervals': [prefix / to_path(f'{idx}.interval_list') for idx in range(1, scatter_count + 1)]}
 
     def queue_jobs(

--- a/src/align_genotype/stages.py
+++ b/src/align_genotype/stages.py
@@ -20,7 +20,7 @@ class GenerateIntervalsOnce(stage.MultiCohortStage):
         scatter_count = config.config_retrieve(['workflow', 'scatter_count_genotype'])
         sequencing_type = config.config_retrieve(['workflow', 'sequencing_type'])
         prefix = (
-            multicohort.analysis_dataset.prefix(category='tmp')
+            multicohort.analysis_dataset.prefix()
             / 'genotype'
             / sequencing_type
             / f'{scatter_count}_intervals'

--- a/src/align_genotype/stages.py
+++ b/src/align_genotype/stages.py
@@ -19,12 +19,7 @@ class GenerateIntervalsOnce(stage.MultiCohortStage):
     def expected_outputs(self, multicohort: targets.MultiCohort) -> dict[str, list[Path]]:
         scatter_count = config.config_retrieve(['workflow', 'scatter_count_genotype'])
         sequencing_type = config.config_retrieve(['workflow', 'sequencing_type'])
-        prefix = (
-            multicohort.analysis_dataset.prefix()
-            / 'genotype'
-            / sequencing_type
-            / f'{scatter_count}_intervals'
-        )
+        prefix = multicohort.analysis_dataset.prefix() / 'genotype' / sequencing_type / f'{scatter_count}_intervals'
         return {'intervals': [prefix / to_path(f'{idx}.interval_list') for idx in range(1, scatter_count + 1)]}
 
     def queue_jobs(


### PR DESCRIPTION
# Purpose

  - Save the intervals files to a path prefixed with the sequencing type and the scatter count, to prevent accidental re-use by pipelines doing different things

see https://cpg-populationanalysis.atlassian.net/browse/RD-1114

## Proposed Changes

  - Add the sequencing type to the path prefix
  - Add the scatter count to the path prefix 

## Checklist

- [ ] Related GitHub Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
