### PR TITLE
Vntyper flexibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg1-1
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.4.16
+ENV VERSION=0.4.17
 
 WORKDIR /align_genotype
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This single-sample workflow has a dedicated entrypoint, and can be operated thro
 
 ```bash
 analysis-runner --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.4.16-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.4.17-1 \
     --config src/align_genotype/config_template.toml \
     --dataset seqr \
     --description 'Single-Sample data generation' \
@@ -36,7 +36,7 @@ This Dataset-level workflow can be run in a similar way, but with a different en
 
 ```bash
 analysis-runner --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.4.16-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.4.17-1 \
     --config src/align_genotype/config_template.toml \
     --dataset seqr \
     --description 'Dataset-Level QC workflow' \
@@ -49,7 +49,7 @@ A third workflow is available to run VNtyper on a set of samples, which can be u
 
 ```bash
 analysis-runner --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.4.16-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.4.17-1 \
     --config src/align_genotype/config_template.toml \
     --config src/align_genotype/vntyper.toml \
     --dataset seqr \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='Dragmap align & genotype workflow, using CPG-Flow'
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.4.16"
+version="0.4.17"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -105,7 +105,7 @@ hail = ["hail", "hailtop"]
 "src/align_genotype/jobs/somalier.py" = ["C901", "PLR0912", "PLR0913", "PLR0915"]  # ignore complexity for this script
 
 [tool.bumpversion]
-current_version = "0.4.16"
+current_version = "0.4.17"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/align_genotype/config_template.toml
+++ b/src/align_genotype/config_template.toml
@@ -134,3 +134,5 @@ vntyper_config_json_path = false
 kestrel_config_json_path = false
 
 vntyper_projects = []
+skip_sgids = []
+fast = false

--- a/src/align_genotype/jobs/vntyper.py
+++ b/src/align_genotype/jobs/vntyper.py
@@ -94,13 +94,16 @@ def vntyper(
         kestrel_config = batch_instance.read_input(kestrel_config_path)
         job.command(f'cp {kestrel_config} ./vntyper/scripts/kestrel_config.json')
 
+    # allow for fast-mode to be triggered
+    fast_mode = '--fast-mode' if config.config_retrieve(['vntyper', 'fast']) else ''
+
     vntyper_command_str = f"""\
     {vntyper_command_prefix} pipeline \
         --cram {cram_resource_group.cram} \
         --reference-assembly hg38 \
         --extra-modules advntr \
         -o ./results \
-        --threads 4"""
+        --threads 4 {fast_mode}"""
 
     job.command(vntyper_command_str)
 

--- a/src/align_genotype/stages.py
+++ b/src/align_genotype/stages.py
@@ -324,9 +324,12 @@ class RunVntyper(stage.SequencingGroupStage):
         """
         Queue the VNtyper job using the function from the jobs module.
         """
-
-        # only run this for a subset of projects, but for all SG IDs in those projects
+        # only run this for a subset of projects
         if sequencing_group.dataset.name not in config.config_retrieve(['vntyper', 'vntyper_projects']):
+            return self.make_outputs(sequencing_group, data=None, jobs=None)
+
+        # allow for skipping this Stage for specific problem samples
+        if sequencing_group.id in config.config_retrieve(['vntyper', 'vntyper_skip_sgids'], []):
             return self.make_outputs(sequencing_group, data=None, jobs=None)
 
         outputs = self.expected_outputs(sequencing_group)

--- a/src/align_genotype/stages.py
+++ b/src/align_genotype/stages.py
@@ -329,7 +329,7 @@ class RunVntyper(stage.SequencingGroupStage):
             return self.make_outputs(sequencing_group, data=None, jobs=None)
 
         # allow for skipping this Stage for specific problem samples
-        if sequencing_group.id in config.config_retrieve(['vntyper', 'vntyper_skip_sgids'], []):
+        if sequencing_group.id in config.config_retrieve(['vntyper', 'skip_sgids'], []):
             return self.make_outputs(sequencing_group, data=None, jobs=None)
 
         outputs = self.expected_outputs(sequencing_group)


### PR DESCRIPTION
# Purpose

  - the vast majority of samples are processing just fine, but we have a very sticky sample unable to finish in reasonable runtimes
  - the current implementation doesn't allow for this sample to be skipped without creating a whole new cohort
  - https://batch.hail.populationgenomics.org.au/batches/1133000/jobs/191
  - https://batch.hail.populationgenomics.org.au/batches/1132989

## Proposed Changes

  - adds an option to skip this stage for specific SG IDs, removing them from consideration without affecting other stages
  - adds an option to trigger 'fast-mode' (VNtyper won't consider unmapped reads)

Eventually we may want to try out shark (pulls relevant reads directly from unmapped FQ files instead of region-filtering + all unmapped reads), but for now we only have a single failing sample, and we don't want to over-index on solving this issue.

Fast mode might work (albeit with mediocre results), and skipping completely will at least get the index page generated.
