### PR TITLE
Qc flag recording

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg1-1
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.4.19
+ENV VERSION=0.4.20
 
 WORKDIR /align_genotype
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This single-sample workflow has a dedicated entrypoint, and can be operated thro
 
 ```bash
 analysis-runner --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.4.19-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.4.20-1 \
     --config src/align_genotype/config_template.toml \
     --dataset seqr \
     --description 'Single-Sample data generation' \
@@ -36,7 +36,7 @@ This Dataset-level workflow can be run in a similar way, but with a different en
 
 ```bash
 analysis-runner --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.4.19-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.4.20-1 \
     --config src/align_genotype/config_template.toml \
     --dataset seqr \
     --description 'Dataset-Level QC workflow' \
@@ -49,7 +49,7 @@ A third workflow is available to run VNtyper on a set of samples, which can be u
 
 ```bash
 analysis-runner --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.4.19-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.4.20-1 \
     --config src/align_genotype/config_template.toml \
     --config src/align_genotype/vntyper.toml \
     --dataset seqr \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='Dragmap align & genotype workflow, using CPG-Flow'
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.4.19"
+version="0.4.20"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -105,7 +105,7 @@ hail = ["hail", "hailtop"]
 "src/align_genotype/jobs/somalier.py" = ["C901", "PLR0912", "PLR0913", "PLR0915"]  # ignore complexity for this script
 
 [tool.bumpversion]
-current_version = "0.4.19"
+current_version = "0.4.20"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/align_genotype/dataset_stages.py
+++ b/src/align_genotype/dataset_stages.py
@@ -99,7 +99,7 @@ class CramMultiQC(stage.DatasetStage):
         return {
             'html': dataset.web_prefix() / qc_subdir / 'cram' / sg_hash / 'multiqc.html',
             'json': dataset.prefix() / qc_subdir / 'cram' / sg_hash / 'multiqc_data.json',
-            'checks': dataset.prefix() / qc_subdir / 'cram' / sg_hash / '.checks',
+            'checks': dataset.prefix() / qc_subdir / 'cram' / sg_hash / 'qc-checks.json',
         }
 
     def queue_jobs(self, dataset: targets.Dataset, inputs: stage.StageInput) -> stage.StageOutput | None:
@@ -208,7 +208,7 @@ class GvcfMultiQC(stage.DatasetStage):
         return {
             'html': dataset.web_prefix() / qc_subdir / 'gvcf' / sg_hash / 'multiqc.html',
             'json': dataset.prefix() / qc_subdir / 'gvcf' / sg_hash / 'multiqc_data.json',
-            'checks': dataset.prefix() / qc_subdir / 'gvcf' / sg_hash / '.checks',
+            'checks': dataset.prefix() / qc_subdir / 'gvcf' / sg_hash / 'qc-checks.json',
         }
 
     def queue_jobs(self, dataset: targets.Dataset, inputs: stage.StageInput) -> stage.StageOutput:

--- a/src/align_genotype/dataset_stages.py
+++ b/src/align_genotype/dataset_stages.py
@@ -194,7 +194,6 @@ def _update_meta(output_path: str) -> dict:
     required_stages=[RunGvcfQc],
     analysis_type='qc',
     analysis_keys=['json'],
-    update_analysis_meta=_update_meta,
 )
 class GvcfMultiQC(stage.DatasetStage):
     """Run MultiQC to summarise all GVCF QC."""

--- a/src/align_genotype/jobs/multiqc.py
+++ b/src/align_genotype/jobs/multiqc.py
@@ -124,6 +124,7 @@ def multiqc(
         record_j = record_qc_flags_job(
             b=batch_instance,
             dataset_name=dataset_name,
+            label=label,
             sg_id_mapping_file=sg_id_mapping_file,
             check_multiqc_json_file=check_j.output,
             job_attrs=job_attrs,
@@ -180,6 +181,7 @@ def check_report_job(
 def record_qc_flags_job(
     b: Batch,
     dataset_name: str,
+    label: str,
     sg_id_mapping_file: ResourceFile,
     check_multiqc_json_file: ResourceFile,
     job_attrs: dict | None = None,
@@ -187,6 +189,7 @@ def record_qc_flags_job(
     """
     Run job that records QC flags in Metamist.
     """
+    report_name = 'CramMultiQC' if label == 'CRAM' else 'GvcfMultiQC' if label == 'GVCF' else 'MultiQC'
     record_j = b.new_job('Record QC flags', (job_attrs or {}) | {'tool': 'python'})
     resources.STANDARD.set_resources(j=record_j, ncpu=2)
     record_j.image(config.config_retrieve(['workflow', 'driver_image']))
@@ -194,6 +197,7 @@ def record_qc_flags_job(
     cmd = f"""\
     python3 -m align_genotype.scripts.record_qc_flags \\
     --dataset {dataset_name} \\
+    --report {report_name} \\
     --qc-flags-json {check_multiqc_json_file} \\
     --sequencing-group-ids-map {sg_id_mapping_file}
     """

--- a/src/align_genotype/jobs/multiqc.py
+++ b/src/align_genotype/jobs/multiqc.py
@@ -118,9 +118,12 @@ def multiqc(
         check_j.depends_on(mqc_j)
         jobs.append(check_j)
 
+        # Important to add the -test suffix as dataset_name is used in GraphQL queries
+        test = config.config_retrieve(['workflow', 'access_level'], None) == 'test'
+        dataset_name = dataset.name + '-test' if test else dataset.name
         record_j = record_qc_flags_job(
             b=batch_instance,
-            dataset_name=dataset.name,
+            dataset_name=dataset_name,
             sg_id_mapping_file=sg_id_mapping_file,
             check_multiqc_json_file=check_j.output,
             job_attrs=job_attrs,

--- a/src/align_genotype/jobs/multiqc.py
+++ b/src/align_genotype/jobs/multiqc.py
@@ -189,7 +189,6 @@ def record_qc_flags_job(
     """
     Run job that records QC flags in Metamist.
     """
-    report_name = 'CramMultiQC' if label == 'CRAM' else 'GvcfMultiQC' if label == 'GVCF' else 'MultiQC'
     record_j = b.new_job('Record QC flags', (job_attrs or {}) | {'tool': 'python'})
     resources.STANDARD.set_resources(j=record_j, ncpu=2)
     record_j.image(config.config_retrieve(['workflow', 'driver_image']))
@@ -197,7 +196,7 @@ def record_qc_flags_job(
     cmd = f"""\
     python3 -m align_genotype.scripts.record_qc_flags \\
     --dataset {dataset_name} \\
-    --report {report_name} \\
+    --label {label} \\
     --qc-flags-json {check_multiqc_json_file} \\
     --sequencing-group-ids-map {sg_id_mapping_file}
     """

--- a/src/align_genotype/jobs/multiqc.py
+++ b/src/align_genotype/jobs/multiqc.py
@@ -59,13 +59,13 @@ def multiqc(
 
     file_list = batch_instance.read_input(file_list_path)
 
-    sample_map_path = tmp_prefix / f'{dataset.get_alignment_inputs_hash()}_rename-sample-map.tsv'
+    sg_id_mapping_file_path = tmp_prefix / f'{dataset.get_alignment_inputs_hash()}_rename-sg-map.tsv'
     if not dry_run:
-        with sample_map_path.open('w') as fh:
+        with sg_id_mapping_file_path.open('w') as fh:
             for sgid, new_sgid in sequencing_group_id_map.items():
                 fh.write('\t'.join([sgid, new_sgid]) + '\n')
 
-    sample_map_file = batch_instance.read_input(sample_map_path)
+    sg_id_mapping_file = batch_instance.read_input(sg_id_mapping_file_path)
 
     joined_endings = ', '.join(ending_to_trim)
     joined_modules = ', '.join(modules_to_trim_endings)
@@ -85,7 +85,7 @@ def multiqc(
         cat {file_list} | gcloud storage cp -I inputs/
 
         multiqc -f inputs -o output \\
-        --replace-names {sample_map_file} \\
+        --replace-names {sg_id_mapping_file} \\
         --title "{title} for dataset <b>{dataset.name}</b>" \\
         --filename report.html \\
         --cl-config "extra_fn_clean_exts: [{joined_endings}]" \\
@@ -120,8 +120,9 @@ def multiqc(
 
         record_j = record_qc_flags_job(
             b=batch_instance,
-            check_multiqc_json_file=check_j.output,
             dataset_name=dataset.name,
+            sg_id_mapping_file=sg_id_mapping_file,
+            check_multiqc_json_file=check_j.output,
             job_attrs=job_attrs,
         )
         record_j.depends_on(check_j)
@@ -175,8 +176,9 @@ def check_report_job(
 
 def record_qc_flags_job(
     b: Batch,
-    check_multiqc_json_file: ResourceFile,
     dataset_name: str,
+    sg_id_mapping_file: ResourceFile,
+    check_multiqc_json_file: ResourceFile,
     job_attrs: dict | None = None,
 ) -> Job:
     """
@@ -189,7 +191,8 @@ def record_qc_flags_job(
     cmd = f"""\
     python3 -m align_genotype.scripts.record_qc_flags \\
     --dataset {dataset_name} \\
-    --qc-flags-json {check_multiqc_json_file}
+    --qc-flags-json {check_multiqc_json_file} \\
+    --sequencing-group-ids-map {sg_id_mapping_file}
     """
 
     record_j.command(cmd)

--- a/src/align_genotype/jobs/multiqc.py
+++ b/src/align_genotype/jobs/multiqc.py
@@ -117,6 +117,16 @@ def multiqc(
         )
         check_j.depends_on(mqc_j)
         jobs.append(check_j)
+
+        record_j = record_qc_flags_job(
+            b=batch_instance,
+            check_multiqc_json_file=check_j.output,
+            dataset_name=dataset.name,
+            job_attrs=job_attrs,
+        )
+        record_j.depends_on(check_j)
+        jobs.append(record_j)
+
     return jobs
 
 
@@ -161,6 +171,29 @@ def check_report_job(
     if out_checks_path:
         b.write_output(check_j.output, str(out_checks_path))
     return check_j
+
+
+def record_qc_flags_job(
+    b: Batch,
+    check_multiqc_json_file: ResourceFile,
+    dataset_name: str,
+    job_attrs: dict | None = None,
+) -> Job:
+    """
+    Run job that records QC flags in Metamist.
+    """
+    record_j = b.new_job('Record QC flags', (job_attrs or {}) | {'tool': 'python'})
+    resources.STANDARD.set_resources(j=record_j, ncpu=2)
+    record_j.image(config.config_retrieve(['workflow', 'driver_image']))
+
+    cmd = f"""\
+    python3 -m align_genotype.scripts.record_qc_flags \\
+    --dataset {dataset_name} \\
+    --qc-flags-json {check_multiqc_json_file}
+    """
+
+    record_j.command(cmd)
+    return record_j
 
 
 def rich_sequencing_group_id_seds(

--- a/src/align_genotype/jobs/multiqc.py
+++ b/src/align_genotype/jobs/multiqc.py
@@ -150,9 +150,9 @@ def check_report_job(
     --html-url {multiqc_html_url} \\
     --dataset {dataset_name} \\
     --title "{title}" \\
+    --output-json {check_j.output} \\
     --{'no-' if not send_to_slack else ''}send-to-slack
 
-    touch {check_j.output}
     echo "HTML URL: {multiqc_html_url}"
     """
 

--- a/src/align_genotype/jobs/multiqc.py
+++ b/src/align_genotype/jobs/multiqc.py
@@ -22,7 +22,7 @@ def multiqc(
     sequencing_group_id_map: dict[str, str],
     extra_config: dict,
     send_to_slack: bool = True,
-) -> Job:
+) -> list[Job]:
     """
     Run MultiQC for the files in `qc_paths`
     @param tmp_prefix: bucket for tmp files

--- a/src/align_genotype/scripts/check_multiqc.py
+++ b/src/align_genotype/scripts/check_multiqc.py
@@ -13,6 +13,8 @@ import json
 import logging
 import pprint
 from collections import defaultdict
+from dataclasses import asdict, dataclass
+from typing import Any
 
 import click
 from cpg_utils import config, to_path
@@ -20,6 +22,15 @@ from cpg_utils.slack import send_message
 
 logging.basicConfig()
 logging.getLogger().setLevel(logging.DEBUG)
+
+
+@dataclass(frozen=True)
+class QcFlag:
+    flag: str
+    value: float
+    threshold: float
+    comparison: str
+    section: str
 
 
 @click.command()
@@ -41,12 +52,18 @@ logging.getLogger().setLevel(logging.DEBUG)
     'send_to_slack',
     help='Send log to Slack message, according to environment variables SLACK_CHANNEL and SLACK_TOKEN',
 )
+@click.option(
+    '--output-json',
+    'output_json_path',
+    help='Path to write structured QC flags JSON output',
+)
 def main(
     multiqc_json_path: str,
     html_url: str | None = None,
     dataset: str | None = None,
     title: str | None = None,
     send_to_slack: bool = True,
+    output_json_path: str | None = None,
 ):
     """
     Check metrics in MultiQC json and send info about failed samples
@@ -58,16 +75,18 @@ def main(
         dataset=dataset,
         title=title,
         send_to_slack=send_to_slack,
+        output_json_path=output_json_path,
     )
 
 
-def run(  # noqa: C901, PLR0912
+def run(  # noqa: C901
     multiqc_json_path: str,
     html_url: str | None = None,
     dataset: str | None = None,
     title: str | None = None,
     send_to_slack: bool = True,
-):
+    output_json_path: str | None = None,
+) -> dict[str, Any]:
     seq_type = config.config_retrieve(['workflow', 'sequencing_type'])
 
     with to_path(multiqc_json_path).open() as f:
@@ -75,7 +94,8 @@ def run(  # noqa: C901, PLR0912
         sections = d['report_general_stats_data']
         logging.info(f'report_general_stats_data: {pprint.pformat(sections)}')
 
-    bad_lines_by_sample = defaultdict(list)
+    bad_lines_by_sample: dict[str, list[str]] = defaultdict(list)
+    qc_flags_by_sample: dict[str, list[QcFlag]] = defaultdict(list)
     for config_key, fail_sign, good_sign, is_fail in [
         (
             'min',
@@ -91,7 +111,7 @@ def run(  # noqa: C901, PLR0912
         ),
     ]:
         threshold_d = config.config_retrieve(['qc_thresholds', seq_type, config_key], {})
-        for section in sections.values():
+        for section_name, section in sections.items():
             for sample, val_by_metric in section.items():
                 for metric, threshold in threshold_d.items():
                     if metric in val_by_metric:
@@ -99,6 +119,16 @@ def run(  # noqa: C901, PLR0912
                         if is_fail(val, threshold):
                             line = f'{metric}={val:0.2f}{fail_sign}{threshold:0.2f}'
                             bad_lines_by_sample[sample].append(line)
+                            cpg_id = sample.split('|', 1)[0]
+                            qc_flags_by_sample[cpg_id].append(
+                                QcFlag(
+                                    flag=metric,
+                                    value=val,
+                                    threshold=threshold,
+                                    comparison=config_key,
+                                    section=section_name,
+                                ),
+                            )
                             logging.info(f'❗ {sample}: {line}')
                         else:
                             line = f'{metric}={val:0.2f}{good_sign}{threshold:0.2f}'
@@ -106,10 +136,8 @@ def run(  # noqa: C901, PLR0912
     logging.info('')
 
     # Constructing Slack message
-    if dataset and html_url:
-        title = f'*[{dataset}]* <{html_url}|{title or "MultiQC report"}>'
-    elif not title:
-        title = 'MultiQC report'
+    report_title = title or 'MultiQC report'
+    title = f'*[{dataset}]* <{html_url}|{report_title}>' if dataset and html_url else report_title
     messages = []
     if bad_lines_by_sample:
         messages.append(f'{title}. {len(bad_lines_by_sample)} samples are flagged:')
@@ -122,6 +150,24 @@ def run(  # noqa: C901, PLR0912
 
     if send_to_slack:
         send_message(text)
+
+    result: dict[str, Any] = {
+        'title': report_title,
+        'dataset': dataset,
+        'html_url': html_url,
+        'sequencing_type': seq_type,
+        'n_samples_flagged': len(qc_flags_by_sample),
+        'qc_flags': {
+            sample: [asdict(flag) for flag in flags]
+            for sample, flags in qc_flags_by_sample.items()
+        },
+    }
+
+    if output_json_path:
+        with to_path(output_json_path).open('w') as f:
+            json.dump(result, f, indent=2)
+
+    return result
 
 
 if __name__ == '__main__':

--- a/src/align_genotype/scripts/check_multiqc.py
+++ b/src/align_genotype/scripts/check_multiqc.py
@@ -26,14 +26,6 @@ logging.basicConfig()
 logging.getLogger().setLevel(logging.DEBUG)
 
 
-def comparison_to_symbol(comparison: str) -> str:
-    if comparison == 'min':
-        return '<'
-    if comparison == 'max':
-        return '>'
-    raise ValueError(f'Unknown comparison type: {comparison}')
-
-
 @click.command()
 @click.option(
     '--multiqc-json',
@@ -128,7 +120,6 @@ def run(  # noqa: C901
                                     comparison=config_key,
                                     threshold=threshold,
                                     section=section_name,
-                                    message=line,
                                     resolved=False,
                                     resolution_date=None,
                                 ),

--- a/src/align_genotype/scripts/check_multiqc.py
+++ b/src/align_genotype/scripts/check_multiqc.py
@@ -82,7 +82,6 @@ def run(  # noqa: C901
     output_json_path: str | None = None,
 ) -> dict[str, Any]:
     seq_type = config.config_retrieve(['workflow', 'sequencing_type'])
-    report = 'CramMultiQC' if 'CRAM' in str(title) else 'GvcfMultiQC' if 'GVCF' in str(title) else 'MultiQC'
 
     today = datetime.now()  # noqa: DTZ005
 
@@ -124,7 +123,6 @@ def run(  # noqa: C901
                                     comparison=fail_sign,
                                     threshold=threshold,
                                     section=section_name,
-                                    report=report,
                                     date=today.isoformat(),
                                     ar_guid=config.try_get_ar_guid(),
                                 ),

--- a/src/align_genotype/scripts/check_multiqc.py
+++ b/src/align_genotype/scripts/check_multiqc.py
@@ -123,7 +123,7 @@ def run(  # noqa: C901
                                     comparison=fail_sign,
                                     threshold=threshold,
                                     section=section_name,
-                                    date=today.isoformat(),
+                                    date=today.isoformat(timespec='seconds'),
                                     ar_guid=config.try_get_ar_guid(),
                                 ),
                             )

--- a/src/align_genotype/scripts/check_multiqc.py
+++ b/src/align_genotype/scripts/check_multiqc.py
@@ -31,7 +31,7 @@ def comparison_to_symbol(comparison: str) -> str:
         return '<'
     if comparison == 'max':
         return '>'
-    raise ValueError(f"Unknown comparison type: {comparison}")
+    raise ValueError(f'Unknown comparison type: {comparison}')
 
 
 @click.command()
@@ -161,10 +161,7 @@ def run(  # noqa: C901
         'html_url': html_url,
         'sequencing_type': seq_type,
         'n_samples_flagged': len(qc_flags_by_sample),
-        'qc_flags': {
-            sample: [asdict(flag) for flag in flags]
-            for sample, flags in qc_flags_by_sample.items()
-        },
+        'qc_flags': {sample: [asdict(flag) for flag in flags] for sample, flags in qc_flags_by_sample.items()},
     }
 
     if output_json_path:

--- a/src/align_genotype/scripts/check_multiqc.py
+++ b/src/align_genotype/scripts/check_multiqc.py
@@ -14,6 +14,7 @@ import logging
 import pprint
 from collections import defaultdict
 from dataclasses import asdict
+from datetime import datetime
 from typing import Any
 
 import click
@@ -81,6 +82,9 @@ def run(  # noqa: C901
     output_json_path: str | None = None,
 ) -> dict[str, Any]:
     seq_type = config.config_retrieve(['workflow', 'sequencing_type'])
+    report = 'CramMultiQC' if 'CRAM' in str(title) else 'GvcfMultiQC' if 'GVCF' in str(title) else 'MultiQC'
+
+    today = datetime.now()  # noqa: DTZ005
 
     with to_path(multiqc_json_path).open() as f:
         d = json.load(f)
@@ -120,8 +124,9 @@ def run(  # noqa: C901
                                     comparison=fail_sign,
                                     threshold=threshold,
                                     section=section_name,
-                                    resolved=False,
-                                    resolution_date=None,
+                                    report=report,
+                                    date=today.isoformat(),
+                                    ar_guid=config.try_get_ar_guid(),
                                 ),
                             )
                             logging.info(f'❗ {sample}: {line}')

--- a/src/align_genotype/scripts/check_multiqc.py
+++ b/src/align_genotype/scripts/check_multiqc.py
@@ -28,9 +28,18 @@ logging.getLogger().setLevel(logging.DEBUG)
 class QcFlag:
     flag: str
     value: float
-    threshold: float
     comparison: str
+    threshold: float
     section: str
+    message: str
+
+
+def comparison_to_symbol(comparison: str) -> str:
+    if comparison == 'min':
+        return '<'
+    if comparison == 'max':
+        return '>'
+    raise ValueError(f"Unknown comparison type: {comparison}")
 
 
 @click.command()
@@ -66,8 +75,8 @@ def main(
     output_json_path: str | None = None,
 ):
     """
-    Check metrics in MultiQC json and send info about failed samples
-    as a Slack message.
+    Check metrics in MultiQC json and compare them against thresholds, then send info about failed samples
+    as a Slack message and save structured QC flags JSON output to a file if specified.
     """
     run(
         multiqc_json_path=multiqc_json_path,
@@ -119,14 +128,15 @@ def run(  # noqa: C901
                         if is_fail(val, threshold):
                             line = f'{metric}={val:0.2f}{fail_sign}{threshold:0.2f}'
                             bad_lines_by_sample[sample].append(line)
-                            cpg_id = sample.split('|', 1)[0]
-                            qc_flags_by_sample[cpg_id].append(
+                            sg_id = sample.split('|', 1)[0]
+                            qc_flags_by_sample[sg_id].append(
                                 QcFlag(
                                     flag=metric,
                                     value=val,
-                                    threshold=threshold,
                                     comparison=config_key,
+                                    threshold=threshold,
                                     section=section_name,
+                                    message=line,
                                 ),
                             )
                             logging.info(f'❗ {sample}: {line}')

--- a/src/align_genotype/scripts/check_multiqc.py
+++ b/src/align_genotype/scripts/check_multiqc.py
@@ -13,25 +13,17 @@ import json
 import logging
 import pprint
 from collections import defaultdict
-from dataclasses import asdict, dataclass
+from dataclasses import asdict
 from typing import Any
 
 import click
 from cpg_utils import config, to_path
 from cpg_utils.slack import send_message
 
+from align_genotype.utils import QcFlag
+
 logging.basicConfig()
 logging.getLogger().setLevel(logging.DEBUG)
-
-
-@dataclass(frozen=True)
-class QcFlag:
-    flag: str
-    value: float
-    comparison: str
-    threshold: float
-    section: str
-    message: str
 
 
 def comparison_to_symbol(comparison: str) -> str:
@@ -137,6 +129,8 @@ def run(  # noqa: C901
                                     threshold=threshold,
                                     section=section_name,
                                     message=line,
+                                    resolved=False,
+                                    resolution_date=None,
                                 ),
                             )
                             logging.info(f'❗ {sample}: {line}')

--- a/src/align_genotype/scripts/check_multiqc.py
+++ b/src/align_genotype/scripts/check_multiqc.py
@@ -117,7 +117,7 @@ def run(  # noqa: C901
                                 QcFlag(
                                     flag=metric,
                                     value=val,
-                                    comparison=config_key,
+                                    comparison=fail_sign,
                                     threshold=threshold,
                                     section=section_name,
                                     resolved=False,

--- a/src/align_genotype/scripts/record_qc_flags.py
+++ b/src/align_genotype/scripts/record_qc_flags.py
@@ -70,6 +70,7 @@ def reconcile_sg_qc_flags(
     new_qc_flags: list[dict] = new_flags_by_sg.get(sg_id, [])
 
     if not current_qc_flags and not new_qc_flags:
+        logger.info(f'{sg_id} :: No existing or new QC flags for this SG, skipping.')
         return  # No existing or new QC flags for this SG, skip
 
     # Key flags by (section, flag) so the same metric in different MultiQC sections
@@ -145,17 +146,30 @@ def reconcile_sg_qc_flags(
     required=True,
     help='Path to the QC flags JSON file',
 )
+@click.option(
+    '--sequencing-group-ids-map',
+    'sg_id_mapping_file',
+    required=True,
+    help='Path to the sequencing group IDs mapping file',
+)
 def main(
     dataset: str,
     qc_flags_json_path: str,
+    sg_id_mapping_file: str,
 ):
     """
-    Reads the qc flags JSON file and updates the sequencing group meta in Metamist.
+    Reads the qc flags JSON file and the SG mapping file, and updates any flagged QC issues in the
+    sequencing group meta in Metamist. The mapping file is required to ensure that the SG was in
+    scope for the dataset being processed and to avoid updating unrelated SGs.
 
     If the SG meta already has a 'qc_flags' key, it will be updated with the new flags, including
     recording resolution information. If the 'qc_flags' key does not exist, it will be created.
     """
     today = datetime.now()  # noqa: DTZ005
+
+    # Load the sequencing group IDs mapping file
+    with open(sg_id_mapping_file) as f:
+        sg_id_map = json.load(f)
 
     # Load the QC flags from the JSON file
     with open(qc_flags_json_path) as f:
@@ -168,7 +182,8 @@ def main(
     # Reconcile each sequencing group's QC flags
     new_flags_by_sg = qc_flags_data['qc_flags']
     for sg in sequencing_groups:
-        reconcile_sg_qc_flags(sg, new_flags_by_sg, dataset, today)
+        if sg['id'] in sg_id_map:
+            reconcile_sg_qc_flags(sg, new_flags_by_sg, dataset, today)
 
 
 if __name__ == '__main__':

--- a/src/align_genotype/scripts/record_qc_flags.py
+++ b/src/align_genotype/scripts/record_qc_flags.py
@@ -40,15 +40,101 @@ SG_META_MUTATION = gql(
 
 def compare_qc_flag(current_flag: dict, new_flag: dict) -> bool:
     """
-    Compares two QC flags and returns True if they are the same, False otherwise.
+    Returns True if the two flags refer to the same QC issue and the current flag is still
+    unresolved. Flag identity is (flag + comparison + threshold + section); the measured
+    `value` is intentionally excluded because it can drift slightly between MultiQC runs.
     """
     return (
         current_flag.get('flag') == new_flag.get('flag')
-        and current_flag.get('value') == new_flag.get('value')
         and current_flag.get('comparison') == new_flag.get('comparison')
         and current_flag.get('threshold') == new_flag.get('threshold')
         and current_flag.get('section') == new_flag.get('section')
-        and not current_flag.get('resolved', False)  # We only want to compare unresolved flags
+        and not current_flag.get('resolved', False)
+    )
+
+
+def reconcile_sg_qc_flags(
+    sg: dict,
+    new_flags_by_sg: dict[str, list[dict]],
+    dataset: str,
+    today: datetime,
+) -> None:
+    """
+    Reconcile current and new QC flags for a single SG and update its meta in Metamist.
+
+    Marks absent flags as resolved, retains unchanged flags, updates differing flags,
+    and adds new flags that didn't previously exist.
+    """
+    sg_id = sg['id']
+    current_qc_flags: list[dict] = (sg['meta'] or {}).get('qc_flags', [])
+    new_qc_flags: list[dict] = new_flags_by_sg.get(sg_id, [])
+
+    if not current_qc_flags and not new_qc_flags:
+        return  # No existing or new QC flags for this SG, skip
+
+    # Key flags by (section, flag) so the same metric in different MultiQC sections
+    # is treated as a distinct QC issue.
+    new_qc_flags_by_key = {(flag['section'], flag['flag']): flag for flag in new_qc_flags}
+    existing_flag_keys = {(flag['section'], flag['flag']) for flag in current_qc_flags}
+    stats = {'resolved': 0, 'retained': 0, 'updated': 0, 'added': 0}
+    final_flags: list[QcFlag] = []
+
+    if current_qc_flags:
+        logger.info(f'{sg_id} :: Found {len(current_qc_flags)} existing QC flags. Reconciling.')
+        for flag in current_qc_flags:
+            key = (flag['section'], flag['flag'])
+            present_in_new = key in new_qc_flags_by_key
+            if not present_in_new:
+                if not flag['resolved']:
+                    # Previously-flagged issue no longer present: mark resolved
+                    flag['resolved'] = True
+                    flag['resolution_date'] = today.isoformat()
+                    stats['resolved'] += 1
+                    logger.info(f"{sg_id} :: Marking QC flag '{flag['flag']}' as resolved.")
+                else:
+                    # Already resolved and still absent: keep as-is
+                    logger.info(f"{sg_id} :: QC flag '{flag['flag']}' remains resolved.")
+            elif compare_qc_flag(flag, new_qc_flags_by_key[key]):
+                # Same unresolved issue is still present: refresh the measured value and
+                # message but keep resolution status. Identity (metric/threshold/section/
+                # comparison) is unchanged so this counts as 'retained', not 'updated'.
+                new_flag = new_qc_flags_by_key[key]
+                flag['value'] = new_flag['value']
+                flag['message'] = new_flag['message']
+                stats['retained'] += 1
+                logger.info(f"{sg_id} :: QC flag '{flag['flag']}' remains unresolved (value refreshed).")
+            else:
+                # Current flag exists in new run but differs (or was resolved and has reappeared):
+                # overwrite with new flag data (which sets resolved=False)
+                flag.update(new_qc_flags_by_key[key])
+                stats['updated'] += 1
+                logger.info(f"{sg_id} :: QC flag '{flag['flag']}' updated with new information.")
+            final_flags.append(QcFlag(**flag))
+    else:
+        logger.info(f'{sg_id} :: No existing QC flags found, adding {len(new_qc_flags)} new flags.')
+
+    # Add new flags that aren't already represented in current_qc_flags
+    for flag in new_qc_flags:
+        if (flag['section'], flag['flag']) in existing_flag_keys:
+            continue
+        flag['resolved'] = False
+        flag['resolution_date'] = None
+        final_flags.append(QcFlag(**flag))
+        stats['added'] += 1
+
+    # Perform the mutation to update the SG meta
+    mutation_response = query(
+        SG_META_MUTATION,
+        variables={
+            'dataset': dataset,
+            'sgId': sg_id,
+            'sgMeta': {'qc_flags': [asdict(flag) for flag in final_flags]},
+        },
+    )
+    logger.info(f'{sg_id} :: {len(final_flags)} total flags. Mutation response: {mutation_response}')
+    logger.info(
+        f'{sg_id} :: Resolved: {stats["resolved"]}, Retained: {stats["retained"]}, '
+        f'Updated: {stats["updated"]}, Added: {stats["added"]}'
     )
 
 
@@ -68,61 +154,14 @@ def main(
     with open(qc_flags_json_path) as f:
         qc_flags_data = json.load(f)
 
-    if not qc_flags_data:
-        logger.info(f'No QC flags found in {qc_flags_json_path}. No updates will be made.')
-        return
-
     # Query the sequencing groups for the given dataset
     response = query(DATASET_SG_META_QUERY, variables={'dataset': dataset})
     sequencing_groups = response['project']['sequencingGroups']
 
-    # Update each sequencing group's meta with the new QC flags
+    # Reconcile each sequencing group's QC flags
+    new_flags_by_sg = qc_flags_data['qc_flags']
     for sg in sequencing_groups:
-        sg_id = sg['id']
-        current_qc_flags: list[dict] = sg['meta'].get('qc_flags', [])
-        new_qc_flags: list[dict] = qc_flags_data['qc_flags'].get(sg_id, [])
-        new_qc_flags_by_flag = {flag['flag']: flag for flag in new_qc_flags}
-
-        if not current_qc_flags and not new_qc_flags:
-            continue  # No existing or new QC flags for this SG, skip
-
-        stats = {'resolved': 0, 'retained': 0}
-        final_flags: list[QcFlag] = []
-        if current_qc_flags:
-            logger.info(f'{sg_id} :: Found {len(current_qc_flags)} existing QC flags. Updating existing flags.')
-            # Compare the current and new QC flags to determine if an update is needed
-
-            for flag in current_qc_flags:
-                if flag['flag'] not in new_qc_flags_by_flag and not flag['resolved']:
-                    # If an unresolved current flag is not in the new flags, mark it resolved on the current date
-                    flag['resolved'] = True
-                    flag['resolution_date'] = today.isoformat()
-                    stats['resolved'] += 1
-                    logger.info(f"{sg_id} :: Marking QC flag '{flag['flag']}' for SG as resolved.")
-                elif compare_qc_flag(flag, new_qc_flags_by_flag[flag['flag']]):
-                    # If the current flag matches the new flag, we retain it
-                    stats['retained'] += 1
-                    logger.info(f"{sg_id} :: QC flag '{flag['flag']}' for SG remains unresolved.")
-                else:
-                    # If the current flag does not match the new flag, we update it
-                    flag.update(new_qc_flags_by_flag[flag['flag']])
-                    stats['retained'] += 1
-                    logger.info(f"{sg_id} :: QC flag '{flag['flag']}' for SG updated with new information.")
-                final_flags.append(QcFlag(**flag))
-        else:
-            logger.info(f'{sg_id} :: No existing QC flags found, adding {len(new_qc_flags)} new flags.')
-
-        for flag in new_qc_flags:
-            flag['resolved'] = False
-            flag['resolution_date'] = None
-            final_flags.append(QcFlag(**flag))
-
-        # Perform the mutation to update the SG meta
-        mutation_response = query(
-            SG_META_MUTATION, variables={'sgId': sg_id, 'sgMeta': {'qc_flags': [asdict(flag) for flag in final_flags]}}
-        )
-        logger.info(f'{sg_id} :: {len(final_flags)} total flags. Mutation response: {mutation_response}')
-        logger.info(f'{sg_id} :: Resolved: {stats["resolved"]}, Retained: {stats["retained"]}')
+        reconcile_sg_qc_flags(sg, new_flags_by_sg, dataset, today)
 
 
 if __name__ == '__main__':

--- a/src/align_genotype/scripts/record_qc_flags.py
+++ b/src/align_genotype/scripts/record_qc_flags.py
@@ -1,0 +1,124 @@
+import json
+from dataclasses import asdict
+from datetime import datetime
+
+from loguru import logger
+from metamist.graphql import gql, query
+
+from align_genotype.utils import QcFlag
+
+DATASET_SG_META_QUERY = gql(
+    """
+    query datasetSgMeta($dataset: String!) {
+        project(name: $dataset) {
+            sequencingGroups {
+                id
+                meta
+            }
+        }
+    }
+    """
+)
+
+SG_META_MUTATION = gql(
+    """
+    mutation updateSgMeta($dataset: String!, $sgId: String!, $sgMeta: JSON!) {
+        sequencingGroup {
+            updateSequencingGroup(
+                project: $dataset
+                sequencingGroup: {id: $sgId, meta: $sgMeta}
+            ) {
+                id
+                meta
+            }
+        }
+    }
+    """
+)
+
+def compare_qc_flag(current_flag: dict, new_flag: dict) -> bool:
+    """
+    Compares two QC flags and returns True if they are the same, False otherwise.
+    """
+    return (
+        current_flag.get('flag') == new_flag.get('flag') and
+        current_flag.get('value') == new_flag.get('value') and
+        current_flag.get('comparison') == new_flag.get('comparison') and
+        current_flag.get('threshold') == new_flag.get('threshold') and
+        current_flag.get('section') == new_flag.get('section') and
+        not current_flag.get('resolved', False)  # We only want to compare unresolved flags
+    )
+
+
+def main(
+    dataset: str,
+    qc_flags_json_path: str,
+):
+    """
+    Reads the qc flags JSON file and updates the sequencing group meta in Metamist.
+
+    If the SG meta already has a 'qc_flags' key, it will be updated with the new flags, including
+    recording resolution information. If the 'qc_flags' key does not exist, it will be created.
+    """
+    today = datetime.now()  # noqa: DTZ005
+
+    # Load the QC flags from the JSON file
+    with open(qc_flags_json_path) as f:
+        qc_flags_data = json.load(f)
+
+    if not qc_flags_data:
+        logger.info(f"No QC flags found in {qc_flags_json_path}. No updates will be made.")
+        return
+
+    # Query the sequencing groups for the given dataset
+    response = query(DATASET_SG_META_QUERY, variables={'dataset': dataset})
+    sequencing_groups = response['project']['sequencingGroups']
+
+    # Update each sequencing group's meta with the new QC flags
+    for sg in sequencing_groups:
+        sg_id = sg['id']
+        current_qc_flags: list[dict] = sg['meta'].get('qc_flags', [])
+        new_qc_flags: list[dict] = qc_flags_data['qc_flags'].get(sg_id, [])
+        new_qc_flags_by_flag = {flag['flag']: flag for flag in new_qc_flags}
+
+        if not current_qc_flags and not new_qc_flags:
+            continue  # No existing or new QC flags for this SG, skip
+
+        stats = {"resolved": 0, "retained": 0}
+        final_flags: list[QcFlag] = []
+        if current_qc_flags:
+            logger.info(f"{sg_id} :: Found {len(current_qc_flags)} existing QC flags. Updating existing flags.")
+            # Compare the current and new QC flags to determine if an update is needed
+
+            for flag in current_qc_flags:
+                if flag['flag'] not in new_qc_flags_by_flag and not flag['resolved']:
+                    # If an unresolved current flag is not in the new flags, mark it resolved on the current date
+                    flag['resolved'] = True
+                    flag['resolution_date'] = today.isoformat()
+                    stats['resolved'] += 1
+                    logger.info(f"{sg_id} :: Marking QC flag '{flag['flag']}' for SG as resolved.")
+                elif compare_qc_flag(flag, new_qc_flags_by_flag[flag['flag']]):
+                    # If the current flag matches the new flag, we retain it
+                    stats['retained'] += 1
+                    logger.info(f"{sg_id} :: QC flag '{flag['flag']}' for SG remains unresolved.")
+                else:
+                    # If the current flag does not match the new flag, we update it
+                    flag.update(new_qc_flags_by_flag[flag['flag']])
+                    stats['retained'] += 1
+                    logger.info(f"{sg_id} :: QC flag '{flag['flag']}' for SG updated with new information.")
+                final_flags.append(QcFlag(**flag))
+        else:
+            logger.info(f"{sg_id} :: No existing QC flags found, adding {len(new_qc_flags)} new flags.")
+
+        for flag in new_qc_flags:
+            flag['resolved'] = False
+            flag['resolution_date'] = None
+            final_flags.append(QcFlag(**flag))
+
+        # Perform the mutation to update the SG meta
+        mutation_response = query(
+            SG_META_MUTATION,
+            variables={ 'sgId': sg_id, 'sgMeta': {'qc_flags': [asdict(flag) for flag in final_flags]}}
+        )
+        logger.info(f"{sg_id} :: {len(final_flags)} total flags. Mutation response: {mutation_response}")
+        logger.info(f"{sg_id} :: Resolved: {stats['resolved']}, Retained: {stats['retained']}")

--- a/src/align_genotype/scripts/record_qc_flags.py
+++ b/src/align_genotype/scripts/record_qc_flags.py
@@ -104,7 +104,7 @@ def reconcile_sg_qc_flags(
                 if not flag['resolved']:
                     # Previously-flagged issue no longer present: mark resolved
                     flag['resolved'] = True
-                    flag['resolution_date'] = today.isoformat()
+                    flag['resolution_date'] = today.isoformat(timespec='seconds')
                     logger.info(f"{sg_id} :: Marking {report} flag '{flag['flag']}' as resolved.")
                     stats['resolved'] += 1
                 else:
@@ -146,7 +146,7 @@ def reconcile_sg_qc_flags(
         },
     )
     logger.info(
-        f'{sg_id} :: recorded {len(final_flags)} {report} flags in Metamist. '
+        f'{sg_id} :: Recorded {len(final_flags)} {report} flags in Metamist. '
         f'Resolved: {stats["resolved"]}, Retained: {stats["retained"]}, '
         f'Updated: {stats["updated"]}, Added: {stats["added"]}'
     )

--- a/src/align_genotype/scripts/record_qc_flags.py
+++ b/src/align_genotype/scripts/record_qc_flags.py
@@ -73,6 +73,11 @@ def reconcile_sg_qc_flags(
         logger.info(f'{sg_id} :: No existing or new QC flags for this SG, skipping.')
         return  # No existing or new QC flags for this SG, skip
 
+    unresolved_current_flags = [flag for flag in current_qc_flags if not flag.get('resolved', False)]
+    if not unresolved_current_flags and not new_qc_flags:
+        logger.info(f'{sg_id} :: No unresolved existing or new QC flags for this SG, skipping.')
+        return  # No unresolved existing or new QC flags for this SG, skip
+
     # Key flags by (section, flag) so the same metric in different MultiQC sections
     # is treated as a distinct QC issue.
     new_qc_flags_by_key = {(flag['section'], flag['flag']): flag for flag in new_qc_flags}

--- a/src/align_genotype/scripts/record_qc_flags.py
+++ b/src/align_genotype/scripts/record_qc_flags.py
@@ -167,9 +167,9 @@ def main(
     """
     today = datetime.now()  # noqa: DTZ005
 
-    # Load the sequencing group IDs mapping file
+    # Load the sequencing group IDs mapping file tsv
     with open(sg_id_mapping_file) as f:
-        sg_id_map = json.load(f)
+        sg_id_map = dict(line.strip().split('\t') for line in f if line.strip())
 
     # Load the QC flags from the JSON file
     with open(qc_flags_json_path) as f:

--- a/src/align_genotype/scripts/record_qc_flags.py
+++ b/src/align_genotype/scripts/record_qc_flags.py
@@ -3,6 +3,7 @@ from dataclasses import asdict
 from datetime import datetime
 
 import click
+from cpg_utils.config import try_get_ar_guid
 from loguru import logger
 from metamist.graphql import gql, query
 
@@ -122,6 +123,8 @@ def reconcile_sg_qc_flags(
     for flag in new_qc_flags:
         if (flag['section'], flag['flag']) in existing_flag_keys:
             continue
+        flag['date'] = today.isoformat()
+        flag['ar_guid'] = try_get_ar_guid()
         flag['resolved'] = False
         flag['resolution_date'] = None
         final_flags.append(QcFlag(**flag))
@@ -137,7 +140,7 @@ def reconcile_sg_qc_flags(
         },
     )
     logger.info(
-        f'{sg_id} :: Updated {len(final_flags)} flags in Metamist. '
+        f'{sg_id} :: recorded {len(final_flags)} flags in Metamist. '
         f'Resolved: {stats["resolved"]}, Retained: {stats["retained"]}, '
         f'Updated: {stats["updated"]}, Added: {stats["added"]}'
     )

--- a/src/align_genotype/scripts/record_qc_flags.py
+++ b/src/align_genotype/scripts/record_qc_flags.py
@@ -1,3 +1,4 @@
+import argparse
 import json
 from dataclasses import asdict
 from datetime import datetime
@@ -36,17 +37,18 @@ SG_META_MUTATION = gql(
     """
 )
 
+
 def compare_qc_flag(current_flag: dict, new_flag: dict) -> bool:
     """
     Compares two QC flags and returns True if they are the same, False otherwise.
     """
     return (
-        current_flag.get('flag') == new_flag.get('flag') and
-        current_flag.get('value') == new_flag.get('value') and
-        current_flag.get('comparison') == new_flag.get('comparison') and
-        current_flag.get('threshold') == new_flag.get('threshold') and
-        current_flag.get('section') == new_flag.get('section') and
-        not current_flag.get('resolved', False)  # We only want to compare unresolved flags
+        current_flag.get('flag') == new_flag.get('flag')
+        and current_flag.get('value') == new_flag.get('value')
+        and current_flag.get('comparison') == new_flag.get('comparison')
+        and current_flag.get('threshold') == new_flag.get('threshold')
+        and current_flag.get('section') == new_flag.get('section')
+        and not current_flag.get('resolved', False)  # We only want to compare unresolved flags
     )
 
 
@@ -67,7 +69,7 @@ def main(
         qc_flags_data = json.load(f)
 
     if not qc_flags_data:
-        logger.info(f"No QC flags found in {qc_flags_json_path}. No updates will be made.")
+        logger.info(f'No QC flags found in {qc_flags_json_path}. No updates will be made.')
         return
 
     # Query the sequencing groups for the given dataset
@@ -84,10 +86,10 @@ def main(
         if not current_qc_flags and not new_qc_flags:
             continue  # No existing or new QC flags for this SG, skip
 
-        stats = {"resolved": 0, "retained": 0}
+        stats = {'resolved': 0, 'retained': 0}
         final_flags: list[QcFlag] = []
         if current_qc_flags:
-            logger.info(f"{sg_id} :: Found {len(current_qc_flags)} existing QC flags. Updating existing flags.")
+            logger.info(f'{sg_id} :: Found {len(current_qc_flags)} existing QC flags. Updating existing flags.')
             # Compare the current and new QC flags to determine if an update is needed
 
             for flag in current_qc_flags:
@@ -108,7 +110,7 @@ def main(
                     logger.info(f"{sg_id} :: QC flag '{flag['flag']}' for SG updated with new information.")
                 final_flags.append(QcFlag(**flag))
         else:
-            logger.info(f"{sg_id} :: No existing QC flags found, adding {len(new_qc_flags)} new flags.")
+            logger.info(f'{sg_id} :: No existing QC flags found, adding {len(new_qc_flags)} new flags.')
 
         for flag in new_qc_flags:
             flag['resolved'] = False
@@ -117,8 +119,16 @@ def main(
 
         # Perform the mutation to update the SG meta
         mutation_response = query(
-            SG_META_MUTATION,
-            variables={ 'sgId': sg_id, 'sgMeta': {'qc_flags': [asdict(flag) for flag in final_flags]}}
+            SG_META_MUTATION, variables={'sgId': sg_id, 'sgMeta': {'qc_flags': [asdict(flag) for flag in final_flags]}}
         )
-        logger.info(f"{sg_id} :: {len(final_flags)} total flags. Mutation response: {mutation_response}")
-        logger.info(f"{sg_id} :: Resolved: {stats['resolved']}, Retained: {stats['retained']}")
+        logger.info(f'{sg_id} :: {len(final_flags)} total flags. Mutation response: {mutation_response}')
+        logger.info(f'{sg_id} :: Resolved: {stats["resolved"]}, Retained: {stats["retained"]}')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Record QC flags in Metamist.')
+    parser.add_argument('--dataset', required=True, help='Dataset name')
+    parser.add_argument('--qc-flags-json', required=True, help='Path to the QC flags JSON file')
+    args = parser.parse_args()
+
+    main(dataset=args.dataset, qc_flags_json_path=args.qc_flags_json)

--- a/src/align_genotype/scripts/record_qc_flags.py
+++ b/src/align_genotype/scripts/record_qc_flags.py
@@ -1,8 +1,8 @@
-import argparse
 import json
 from dataclasses import asdict
 from datetime import datetime
 
+import click
 from loguru import logger
 from metamist.graphql import gql, query
 
@@ -123,7 +123,7 @@ def reconcile_sg_qc_flags(
         stats['added'] += 1
 
     # Perform the mutation to update the SG meta
-    mutation_response = query(
+    query(
         SG_META_MUTATION,
         variables={
             'dataset': dataset,
@@ -131,13 +131,21 @@ def reconcile_sg_qc_flags(
             'sgMeta': {'qc_flags': [asdict(flag) for flag in final_flags]},
         },
     )
-    logger.info(f'{sg_id} :: {len(final_flags)} total flags. Mutation response: {mutation_response}')
     logger.info(
-        f'{sg_id} :: Resolved: {stats["resolved"]}, Retained: {stats["retained"]}, '
+        f'{sg_id} :: Updated {len(final_flags)} flags in Metamist. '
+        f'Resolved: {stats["resolved"]}, Retained: {stats["retained"]}, '
         f'Updated: {stats["updated"]}, Added: {stats["added"]}'
     )
 
 
+@click.command()
+@click.option('--dataset', required=True, help='Dataset name')
+@click.option(
+    '--qc-flags-json',
+    'qc_flags_json_path',
+    required=True,
+    help='Path to the QC flags JSON file',
+)
 def main(
     dataset: str,
     qc_flags_json_path: str,
@@ -165,9 +173,4 @@ def main(
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Record QC flags in Metamist.')
-    parser.add_argument('--dataset', required=True, help='Dataset name')
-    parser.add_argument('--qc-flags-json', required=True, help='Path to the QC flags JSON file')
-    args = parser.parse_args()
-
-    main(dataset=args.dataset, qc_flags_json_path=args.qc_flags_json)
+    main()  # pylint: disable=E1120

--- a/src/align_genotype/scripts/record_qc_flags.py
+++ b/src/align_genotype/scripts/record_qc_flags.py
@@ -96,11 +96,10 @@ def reconcile_sg_qc_flags(
                     logger.info(f"{sg_id} :: QC flag '{flag['flag']}' remains resolved.")
             elif compare_qc_flag(flag, new_qc_flags_by_key[key]):
                 # Same unresolved issue is still present: refresh the measured value and
-                # message but keep resolution status. Identity (metric/threshold/section/
+                # but keep resolution status. Identity (metric/threshold/section/
                 # comparison) is unchanged so this counts as 'retained', not 'updated'.
                 new_flag = new_qc_flags_by_key[key]
                 flag['value'] = new_flag['value']
-                flag['message'] = new_flag['message']
                 stats['retained'] += 1
                 logger.info(f"{sg_id} :: QC flag '{flag['flag']}' remains unresolved (value refreshed).")
             else:

--- a/src/align_genotype/scripts/record_qc_flags.py
+++ b/src/align_genotype/scripts/record_qc_flags.py
@@ -57,22 +57,23 @@ def reconcile_sg_qc_flags(
     sg: dict,
     new_flags_by_sg: dict[str, list[dict]],
     dataset: str,
-    report: str,
+    label: str,
     today: datetime,
 ) -> None:
     """
     Reconcile current and new QC flags for a single SG and update its meta in Metamist.
 
-    Only considers flags for the specified report (CramMultiQC or GvcfMultiQC).
+    Only considers flags of the type specified by the label (CRAM or GVCF).
 
     Marks absent flags as resolved, retains unchanged flags, updates differing flags,
     and adds new flags that didn't previously exist.
     """
     sg_id = sg['id']
+    report = 'CramMultiQC' if label == 'CRAM' else 'GvcfMultiQC' if label == 'GVCF' else 'MultiQC'
 
-    # Get all the existing QC flags for this SG and filter to only those for the specified report
-    all_current_qc_flags: list[dict] = (sg['meta'] or {}).get('qc_flags', [])
-    current_qc_flags = [flag for flag in all_current_qc_flags if flag.get('report') == report]
+    # Get all the existing QC flags of the specified type for this SG
+    qc_flags_key = f'{label.lower()}_qc_flags'
+    current_qc_flags: list[dict] = (sg['meta'] or {}).get(qc_flags_key, [])
     unresolved_current_flags = [flag for flag in current_qc_flags if not flag.get('resolved', False)]
 
     new_qc_flags: list[dict] = new_flags_by_sg.get(sg_id, [])
@@ -135,16 +136,13 @@ def reconcile_sg_qc_flags(
         final_flags.append(QcFlag(**flag))
         stats['added'] += 1
 
-    # Finally, add back any existing flags from the other reports so they are preserved
-    final_flags.extend(QcFlag(**flag) for flag in all_current_qc_flags if flag.get('report') != report)
-
     # Perform the mutation to update the SG meta
     query(
         SG_META_MUTATION,
         variables={
             'dataset': dataset,
             'sgId': sg_id,
-            'sgMeta': {'qc_flags': [asdict(flag) for flag in final_flags]},
+            'sgMeta': {qc_flags_key: [asdict(flag) for flag in final_flags]},
         },
     )
     logger.info(
@@ -156,7 +154,7 @@ def reconcile_sg_qc_flags(
 
 @click.command()
 @click.option('--dataset', required=True, help='Dataset name')
-@click.option('--report', required=True, help='Report name (CramMultiQC or GvcfMultiQC)')
+@click.option('--label', required=True, help='Report type (CRAM or GVCF)')
 @click.option(
     '--qc-flags-json',
     'qc_flags_json_path',
@@ -171,7 +169,7 @@ def reconcile_sg_qc_flags(
 )
 def main(
     dataset: str,
-    report: str,
+    label: str,
     qc_flags_json_path: str,
     sg_id_mapping_file: str,
 ):
@@ -201,7 +199,7 @@ def main(
     new_flags_by_sg = qc_flags_data['qc_flags']
     for sg in sequencing_groups:
         if sg['id'] in sg_id_map:
-            reconcile_sg_qc_flags(sg, new_flags_by_sg, dataset, report, today)
+            reconcile_sg_qc_flags(sg, new_flags_by_sg, dataset, label, today)
 
 
 if __name__ == '__main__':

--- a/src/align_genotype/scripts/record_qc_flags.py
+++ b/src/align_genotype/scripts/record_qc_flags.py
@@ -3,7 +3,6 @@ from dataclasses import asdict
 from datetime import datetime
 
 import click
-from cpg_utils.config import try_get_ar_guid
 from loguru import logger
 from metamist.graphql import gql, query
 
@@ -58,36 +57,45 @@ def reconcile_sg_qc_flags(
     sg: dict,
     new_flags_by_sg: dict[str, list[dict]],
     dataset: str,
+    report: str,
     today: datetime,
 ) -> None:
     """
     Reconcile current and new QC flags for a single SG and update its meta in Metamist.
 
+    Only considers flags for the specified report (CramMultiQC or GvcfMultiQC).
+
     Marks absent flags as resolved, retains unchanged flags, updates differing flags,
     and adds new flags that didn't previously exist.
     """
     sg_id = sg['id']
-    current_qc_flags: list[dict] = (sg['meta'] or {}).get('qc_flags', [])
+
+    # Get all the existing QC flags for this SG and filter to only those for the specified report
+    all_current_qc_flags: list[dict] = (sg['meta'] or {}).get('qc_flags', [])
+    current_qc_flags = [flag for flag in all_current_qc_flags if flag.get('report') == report]
+    unresolved_current_flags = [flag for flag in current_qc_flags if not flag.get('resolved', False)]
+
     new_qc_flags: list[dict] = new_flags_by_sg.get(sg_id, [])
 
     if not current_qc_flags and not new_qc_flags:
-        logger.info(f'{sg_id} :: No existing or new QC flags for this SG, skipping.')
+        logger.info(f'{sg_id} :: No existing or new {report} flags for this SG, skipping.')
         return  # No existing or new QC flags for this SG, skip
 
-    unresolved_current_flags = [flag for flag in current_qc_flags if not flag.get('resolved', False)]
     if not unresolved_current_flags and not new_qc_flags:
-        logger.info(f'{sg_id} :: No unresolved existing or new QC flags for this SG, skipping.')
+        logger.info(f'{sg_id} :: No unresolved existing or new {report} flags for this SG, skipping.')
         return  # No unresolved existing or new QC flags for this SG, skip
 
     # Key flags by (section, flag) so the same metric in different MultiQC sections
     # is treated as a distinct QC issue.
     new_qc_flags_by_key = {(flag['section'], flag['flag']): flag for flag in new_qc_flags}
     existing_flag_keys = {(flag['section'], flag['flag']) for flag in current_qc_flags}
-    stats = {'resolved': 0, 'retained': 0, 'updated': 0, 'added': 0}
+
+    # Track the final set of flags to be recorded in Metamist, including resolved, retained, updated, and added flags
     final_flags: list[QcFlag] = []
+    stats = {'resolved': 0, 'retained': 0, 'updated': 0, 'added': 0}
 
     if current_qc_flags:
-        logger.info(f'{sg_id} :: Found {len(current_qc_flags)} existing QC flags. Reconciling.')
+        logger.info(f'{sg_id} :: Found {len(current_qc_flags)} existing {report} flags. Reconciling.')
         for flag in current_qc_flags:
             key = (flag['section'], flag['flag'])
             present_in_new = key in new_qc_flags_by_key
@@ -96,39 +104,39 @@ def reconcile_sg_qc_flags(
                     # Previously-flagged issue no longer present: mark resolved
                     flag['resolved'] = True
                     flag['resolution_date'] = today.isoformat()
+                    logger.info(f"{sg_id} :: Marking {report} flag '{flag['flag']}' as resolved.")
                     stats['resolved'] += 1
-                    logger.info(f"{sg_id} :: Marking QC flag '{flag['flag']}' as resolved.")
                 else:
                     # Already resolved and still absent: keep as-is
-                    logger.info(f"{sg_id} :: QC flag '{flag['flag']}' remains resolved.")
+                    logger.info(f"{sg_id} :: {report} flag '{flag['flag']}' remains resolved.")
             elif compare_qc_flag(flag, new_qc_flags_by_key[key]):
                 # Same unresolved issue is still present: refresh the measured value and
                 # but keep resolution status. Identity (metric/threshold/section/
                 # comparison) is unchanged so this counts as 'retained', not 'updated'.
                 new_flag = new_qc_flags_by_key[key]
                 flag['value'] = new_flag['value']
+                logger.info(f"{sg_id} :: {report} flag '{flag['flag']}' remains unresolved (value refreshed).")
                 stats['retained'] += 1
-                logger.info(f"{sg_id} :: QC flag '{flag['flag']}' remains unresolved (value refreshed).")
             else:
                 # Current flag exists in new run but differs (or was resolved and has reappeared):
                 # overwrite with new flag data (which sets resolved=False)
                 flag.update(new_qc_flags_by_key[key])
+                logger.info(f"{sg_id} :: {report} flag '{flag['flag']}' updated with new information.")
                 stats['updated'] += 1
-                logger.info(f"{sg_id} :: QC flag '{flag['flag']}' updated with new information.")
             final_flags.append(QcFlag(**flag))
     else:
-        logger.info(f'{sg_id} :: No existing QC flags found, adding {len(new_qc_flags)} new flags.')
+        logger.info(f'{sg_id} :: No existing {report} flags found, adding {len(new_qc_flags)} new flags.')
 
     # Add new flags that aren't already represented in current_qc_flags
     for flag in new_qc_flags:
         if (flag['section'], flag['flag']) in existing_flag_keys:
             continue
-        flag['date'] = today.isoformat()
-        flag['ar_guid'] = try_get_ar_guid()
-        flag['resolved'] = False
-        flag['resolution_date'] = None
+        logger.info(f"{sg_id} :: Adding new {report} flag '{flag['flag']}'.")
         final_flags.append(QcFlag(**flag))
         stats['added'] += 1
+
+    # Finally, add back any existing flags from the other reports so they are preserved
+    final_flags.extend(QcFlag(**flag) for flag in all_current_qc_flags if flag.get('report') != report)
 
     # Perform the mutation to update the SG meta
     query(
@@ -140,7 +148,7 @@ def reconcile_sg_qc_flags(
         },
     )
     logger.info(
-        f'{sg_id} :: recorded {len(final_flags)} flags in Metamist. '
+        f'{sg_id} :: recorded {len(final_flags)} {report} flags in Metamist. '
         f'Resolved: {stats["resolved"]}, Retained: {stats["retained"]}, '
         f'Updated: {stats["updated"]}, Added: {stats["added"]}'
     )
@@ -148,6 +156,7 @@ def reconcile_sg_qc_flags(
 
 @click.command()
 @click.option('--dataset', required=True, help='Dataset name')
+@click.option('--report', required=True, help='Report name (CramMultiQC or GvcfMultiQC)')
 @click.option(
     '--qc-flags-json',
     'qc_flags_json_path',
@@ -162,6 +171,7 @@ def reconcile_sg_qc_flags(
 )
 def main(
     dataset: str,
+    report: str,
     qc_flags_json_path: str,
     sg_id_mapping_file: str,
 ):
@@ -191,7 +201,7 @@ def main(
     new_flags_by_sg = qc_flags_data['qc_flags']
     for sg in sequencing_groups:
         if sg['id'] in sg_id_map:
-            reconcile_sg_qc_flags(sg, new_flags_by_sg, dataset, today)
+            reconcile_sg_qc_flags(sg, new_flags_by_sg, dataset, report, today)
 
 
 if __name__ == '__main__':

--- a/src/align_genotype/utils.py
+++ b/src/align_genotype/utils.py
@@ -14,8 +14,9 @@ class QcFlag:
     comparison: str
     threshold: float
     section: str
-    ar_guid: str | None = None
-    date: str | None = None
+    report: str
+    date: str
+    ar_guid: str
     resolved: bool = False
     resolution_date: str | None = None
 

--- a/src/align_genotype/utils.py
+++ b/src/align_genotype/utils.py
@@ -14,7 +14,6 @@ class QcFlag:
     comparison: str
     threshold: float
     section: str
-    report: str
     date: str
     ar_guid: str
     resolved: bool = False

--- a/src/align_genotype/utils.py
+++ b/src/align_genotype/utils.py
@@ -1,8 +1,22 @@
+from dataclasses import dataclass
+
 import numpy as np
 import pandas as pd
 from cpg_utils import to_path
 
 NEGATIVES = ['Not flagged', 'Not applicable', 'None', None, pd.NA, np.nan]
+
+
+@dataclass(frozen=True)
+class QcFlag:
+    flag: str
+    value: float
+    comparison: str
+    threshold: float
+    section: str
+    message: str
+    resolved: bool = False
+    resolution_date: str | None = None
 
 
 def scan_vntyper_html(html_file: str) -> dict[str, bool]:

--- a/src/align_genotype/utils.py
+++ b/src/align_genotype/utils.py
@@ -14,6 +14,8 @@ class QcFlag:
     comparison: str
     threshold: float
     section: str
+    ar_guid: str | None = None
+    date: str | None = None
     resolved: bool = False
     resolution_date: str | None = None
 

--- a/src/align_genotype/utils.py
+++ b/src/align_genotype/utils.py
@@ -14,7 +14,6 @@ class QcFlag:
     comparison: str
     threshold: float
     section: str
-    message: str
     resolved: bool = False
     resolution_date: str | None = None
 


### PR DESCRIPTION
# Purpose

  - The MultiQC results are parsed and any qc flags are reported to Slack - but beyond this, they aren't recorded anywhere. This change updates the `check_multiqc` job so that qc flags are saved to the checks output file (now a JSON), and then a new job - `record_qc_flags` - will scan this file and the relevant Metamist records, upserting QC flags in each SG's `meta.{type}_qc_flags` as flags are discovered, changed, or resolved (where `type = 'cram' or 'gvcf').


## Proposed Changes

  - Add structured output to the `check_multiqc` job and change the `checks` filepath to a JSON that will contain results from the checking
  - Add a new job `record_qc_flags` which uses GraphQL queries and mutations to interact with Metamist and record QC flags in each SG's `meta` dictionary
    - Specifically, update the `sg.meta.cram_qc_flags` and `sg.meta.gvcf_qc_flags` depending on which stage the job is invoked from


## A note on the "resolution" of QC flags:
Even though the QC flags will have a `resolved` boolean field and a `resolution_date` field, these are unlikely to be used at present. This is because a QC flag can't really just magically be resolved for a given SG, unless we change the threshold values to make it pass some previously failed comparison, or maybe in some fringe case where we have botched the aligning / genotyping and re-processing fixes the CRAM/GVCF and makes it pass. 

In general, these kinds of QC issues only get resolved by re-sequencing or adding top-up sequencing - both of which would create a new sequencing group, meaning these flags in `SG.meta` would never be marked as resolved.

**So why include these fields if they won't typically be used? Two reasons.**
1. At some point we may want to lift or copy these QC results up a level or two - either to the `sample` or `participant` entity in Metamist. At the participant / sample level it makes sense to mark issues as `resolved` or not, as the `participant` entity will remain consistent even after resequencing, and often the `sample` entity also remains consistent after top-up sequencing. 
2. A similar project as this will be undertaken for **_relatedness_** checking via Somalier. Relatedness issues are treated similarly to QC flags - but the difference is relatedness issues **can** often be resolved without modifying the sequencing group, because often the SG is fine but the pedigree is not. To be consistent with that future work, it makes sense to have the resolution fields in these `qc_flags` records.

## Checklist

- [ ] Related GitHub Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
