### PR TITLE
Add dupblaster as a duplicate marker

### DIFF
--- a/.github/workflows/dev_auto_build.yaml
+++ b/.github/workflows/dev_auto_build.yaml
@@ -23,7 +23,6 @@ jobs:
   get_next_version:
     runs-on: ubuntu-latest
     environment: development
-    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
     outputs:
       matrix: ${{ steps.get_next_version.outputs.next_version }}
     steps:

--- a/.github/workflows/dev_auto_build.yaml
+++ b/.github/workflows/dev_auto_build.yaml
@@ -1,13 +1,15 @@
 name: Autobuild development image
-on:
-  push:
-    branches-ignore:
-      - main
-  workflow_dispatch:
+
+on: [pull_request]
 
 permissions:
   id-token: write
   contents: read
+
+# only build one set of images in the event of multiple pushes in quick succession
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
 
 env:
   PROJECT: 'cpg-common'
@@ -82,11 +84,13 @@ jobs:
       - name: 'gcloud docker auth'
         run: |
           gcloud auth configure-docker ${{ env.DOCKER_PREFIX }}
+
       - name: 'build image with get_next_version'
         run: |
           docker build . -f Dockerfile \
           --build-arg VERSION=${{ matrix.tag }} \
           --tag ${{ env.IMAGES_PREFIX }}/${{ matrix.name }}:${{ matrix.tag }}
+
       - name: 'Push to dev artifactory'
         run: |
           docker push "${{ env.IMAGES_PREFIX }}/${{ matrix.name }}:${{ matrix.tag }}" | tee push.log

--- a/.github/workflows/dev_auto_build.yaml
+++ b/.github/workflows/dev_auto_build.yaml
@@ -60,7 +60,7 @@ jobs:
     environment: development
     needs:
       - get_next_version
-    if: ${{ needs.get_next_version.outputs.matrix != '{"include":[]}' && needs.get_next_version.outputs.matrix != '' && github.event_name == 'push' }}
+    if: ${{ needs.get_next_version.outputs.matrix != '{"include":[]}' && needs.get_next_version.outputs.matrix != '' }}
     strategy:
       matrix: ${{ fromJson(needs.get_next_version.outputs.matrix) }}
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,32 @@
+FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg2-1 AS build
+
+# set bash as the shell of choice
+SHELL ["/bin/bash", "-c"]
+
+# install build-essential for compiling
+# install Rust & Cargo to facilitate install of dupblaster
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends build-essential && \
+    curl https://sh.rustup.rs -sSf | bash -s -- -y && \
+    echo 'source $HOME/.cargo/env' >> $HOME/.bashrc && \
+    source $HOME/.bashrc && \
+    cargo install dupblaster
+
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg2-1
+
+COPY --from=build /root/.cargo/bin/dupblaster /usr/local/bin/dupblaster
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV VERSION=0.4.19
+
+# Install samtools and pip packages
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends samtools && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /align_genotype
 
 COPY src src/
 COPY LICENSE pyproject.toml README.md ./
-
-# Install samtools and pip packages
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends build-essential samtools && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    pip install .
-
-# set bash as the shell of choice
-SHELL ["/bin/bash", "-c"]
-
-# install Rust & Cargo to facilitate streamed running of dupblaster
-RUN curl https://sh.rustup.rs -sSf | bash -s -- -y && \
-    echo 'source $HOME/.cargo/env' >> $HOME/.bashrc && \
-    source $HOME/.bashrc \
-    cargo install dupblaster
+RUN pip install .

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,11 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         build-essential \
         bzip2 \
-        gcc \
         libbz2-dev \
         libcurl4-openssl-dev \
         liblzma-dev \
         libncurses5-dev \
         libssl-dev \
-        make \
         wget \
         zlib1g-dev && \
     curl https://sh.rustup.rs -sSf | bash -s -- -y && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg1-1
+FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg2-1
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV VERSION=0.4.19
@@ -10,8 +10,16 @@ COPY LICENSE pyproject.toml README.md ./
 
 # Install samtools and pip packages
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends samtools && \
+    apt-get install -y --no-install-recommends build-essential samtools && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    pip install --no-cache-dir . && \
-    pip install --no-cache-dir pysam
+    pip install .
+
+# set bash as the shell of choice
+SHELL ["/bin/bash", "-c"]
+
+# install Rust & Cargo to facilitate streamed running of dupblaster
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y && \
+    echo 'source $HOME/.cargo/env' >> $HOME/.bashrc && \
+    source $HOME/.bashrc \
+    cargo install dupblaster

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,24 +6,56 @@ SHELL ["/bin/bash", "-c"]
 # install build-essential for compiling
 # install Rust & Cargo to facilitate install of dupblaster
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends build-essential && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        bzip2 \
+        gcc \
+        libbz2-dev \
+        libcurl4-openssl-dev \
+        liblzma-dev \
+        libncurses5-dev \
+        libssl-dev \
+        make \
+        wget \
+        zlib1g-dev && \
     curl https://sh.rustup.rs -sSf | bash -s -- -y && \
     echo 'source $HOME/.cargo/env' >> $HOME/.bashrc && \
     source $HOME/.bashrc && \
     cargo install dupblaster
 
+ENV SAMTOOLS_VERSION=1.23.1
+
+	# Install samtools
+RUN wget https://github.com/samtools/samtools/releases/download/${SAMTOOLS_VERSION}/samtools-${SAMTOOLS_VERSION}.tar.bz2 && \
+    tar -xf samtools-${SAMTOOLS_VERSION}.tar.bz2 && \
+    cd samtools-${SAMTOOLS_VERSION} && \
+    ./configure --enable-libcurl --enable-s3 --enable-gcs && \
+    make && \
+    make DESTDIR=/samtools_install install && \
+    make -C htslib-${SAMTOOLS_VERSION} DESTDIR=/samtools_install install
+
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg2-1
 
+# copy in dupblaster
 COPY --from=build /root/.cargo/bin/dupblaster /usr/local/bin/dupblaster
+
+# copy in samtools
+COPY --from=build /samtools_install/usr/local/bin/* /usr/local/bin/
+
+# update, install packages required for samtools, clear lists
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        libbz2-1.0 \
+        libcurl4 \
+        liblzma5 \
+        libncurses5-dev \
+        libssl1.1 \
+        zlib1g && \
+    rm -r /var/lib/apt/lists/* && \
+    rm -r /var/cache/apt/*
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV VERSION=0.4.19
-
-# Install samtools and pip packages
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends samtools && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /align_genotype
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,10 +22,10 @@ classifiers=[
 
 dependencies=[
     'cpg-flow~=1.3',
-    'hatchling',
     'jinja2',
     'lxml',
     'peddy',
+    'pysam',
     'slack_sdk',
 ]
 

--- a/src/align_genotype/config_template.toml
+++ b/src/align_genotype/config_template.toml
@@ -80,7 +80,7 @@ plots_force_interactive = true
 ref_fasta = "gs://cpg-common-main/references/hg38/v0/dragen_reference/Homo_sapiens_assembly38_masked.fasta"
 
 [images]
-dragmap = "australia-southeast1-docker.pkg.dev/cpg-common/images/dragmap_plus_ora:2.7.0-1"
+dragmap = "australia-southeast1-docker.pkg.dev/cpg-common/images-dev/dragmap_ora_dupblaster:2.7.0-1"
 gatk = "australia-southeast1-docker.pkg.dev/cpg-common/images/gatk:4.6.2.0-2"
 picard = "australia-southeast1-docker.pkg.dev/cpg-common/images/picard:3.4.0-3"
 samtools = "australia-southeast1-docker.pkg.dev/cpg-common/images/samtools:1.18"

--- a/src/align_genotype/config_template.toml
+++ b/src/align_genotype/config_template.toml
@@ -1,5 +1,8 @@
 [workflow]
 
+# the method to register outputs, can be missing - will not generate metamist analysis entries
+status_reporter = 'metamist'
+
 skip_stages = []
 
 # set this to false if we want to use non-preemptible machines
@@ -12,28 +15,11 @@ genome_realignment_shards = 10
 # use the HIGHMEM template machine type for alignment
 align_use_highmem = false
 
-# whether to bank the sorted BAM to GCP (temp) prior to markdup
-checkpoint_sorted_bam = false
-
 # number of threads to use for alignment, defaulting to 32 on a 16-core machine
 #align_threads
 
 # to manually set the storage attached to align jobs
 #align_storage = 100
-
-# Set to false to disable the use of spot instances for the Picard MarkDuplicates jobs, which
-# can be particularly long-running and prone to multiple pre-emptions for some large sequencing groups
-picard_spot = true
-
-# set to assign a specific amount of RAM to the picard jobs, defaults available
-#picard_mem_gb
-
-# overhead to add to the memory request for picard markduplicates
-picard_markdup_exome_overhead_gb = 1.0
-picard_markdup_genome_overhead_gb = 5.0
-
-# Maximum number of records to keep in RAM for Picard MarkDuplicates
-# picard_markdup_max_records_in_ram =
 
 # set to use highmem workers for picard qc metrics jobs, defaults to false
 picard_metrics_use_highmem = false
@@ -42,12 +28,6 @@ picard_metrics_mem_gb = 8
 
 # set to override the picard attached storage, default 250
 picard_storage_gb = 250
-
-# used to make sure we don't repeat previously completed stages
-check_expected_outputs = true
-
-# the method to register outputs, can be missing - will not generate metamist analysis entries
-status_reporter = 'metamist'
 
 # defaults for the storage to attach to QC jobs for the CRAM file
 exome_cram_gb = 20

--- a/src/align_genotype/jobs/align.py
+++ b/src/align_genotype/jobs/align.py
@@ -326,7 +326,7 @@ def _align_one(  # noqa: PLR0915
     {prepare_fastq_cmd}
     dragen-os -r {dragmap_index} {input_params} \\
         --RGID {sequencing_group_name} --RGSM {sequencing_group_name} \\
-        --num-threads {nthreads - 1} | dupblaster |
+        --num-threads {nthreads - 1} | dupblaster
     """
 
     # prepare command for adding sort on the end

--- a/src/align_genotype/jobs/align.py
+++ b/src/align_genotype/jobs/align.py
@@ -157,7 +157,7 @@ def align(
     fasta_reference = hail_batch.fasta_res_group(batch_instance)
 
     # now finish as a CRAM
-    align_cmd += f""" samtools view --write-index -@{nthreads - 1} \\
+    align_cmd += f""" samtools view --write-index -@{nthreads} \\
         -T {fasta_reference.base} \\
         -O cram,version=3.0 \\
         -o {merge_or_align_j.output_cram.cram}

--- a/src/align_genotype/jobs/align.py
+++ b/src/align_genotype/jobs/align.py
@@ -127,10 +127,7 @@ def align(
         merge_or_align_j = merge_j
         stdout_is_sorted = True
 
-    # add in dupblaster streaming
-    align_cmd += f' | dupblaster --stats stats.tsv | '
-
-    # get number of threads for VM tempalte
+    # get number of threads for VM template
     vm_resources = resources.HIGHMEM.request_resources(
         nthreads=config.config_retrieve(
             ['workflow', 'align_threads'],
@@ -164,7 +161,6 @@ def align(
     """
 
     merge_or_align_j.command(hail_batch.command(align_cmd, monitor_space=True))
-    merge_or_align_j.command(f'mv stats.tsv {merge_or_align_j.stats}')
 
     batch_instance.write_output(merge_or_align_j.stats, markdup_metrics_path)
     batch_instance.write_output(merge_or_align_j.output_cram, str(output_path.with_suffix('')))
@@ -332,7 +328,7 @@ def _align_one(  # noqa: PLR0915
     {prepare_fastq_cmd}
     dragen-os -r {dragmap_index} {input_params} \\
         --RGID {sequencing_group_name} --RGSM {sequencing_group_name} \\
-        --num-threads {nthreads - 1}
+        --num-threads {nthreads - 1} | dupblaster |
     """
 
     # prepare command for adding sort on the end

--- a/src/align_genotype/jobs/align.py
+++ b/src/align_genotype/jobs/align.py
@@ -130,8 +130,6 @@ def align(
     # add in dupblaster streaming
     align_cmd += f' | dupblaster --stats {merge_or_align_j.stats} | '
 
-    batch_instance.write_output(merge_or_align_j.stats, markdup_metrics_path)
-
     # get number of threads for VM tempalte
     vm_resources = resources.HIGHMEM.request_resources(
         nthreads=config.config_retrieve(
@@ -167,6 +165,7 @@ def align(
 
     merge_or_align_j.command(hail_batch.command(align_cmd, monitor_space=True))
 
+    batch_instance.write_output(merge_or_align_j.stats, markdup_metrics_path)
     batch_instance.write_output(merge_or_align_j.output_cram, str(output_path.with_suffix('')))
 
     return jobs

--- a/src/align_genotype/jobs/align.py
+++ b/src/align_genotype/jobs/align.py
@@ -17,7 +17,6 @@ def align(
     sequencing_group: targets.SequencingGroup,
     job_attrs: dict,
     output_path: Path,
-    markdup_metrics_path: str,
 ) -> list[BashJob]:
     """
     - if the input is 1 fastq pair, submits one alignment job.
@@ -162,7 +161,6 @@ def align(
 
     merge_or_align_j.command(hail_batch.command(align_cmd, monitor_space=True))
 
-    batch_instance.write_output(merge_or_align_j.stats, markdup_metrics_path)
     batch_instance.write_output(merge_or_align_j.output_cram, str(output_path.with_suffix('')))
 
     return jobs

--- a/src/align_genotype/jobs/align.py
+++ b/src/align_genotype/jobs/align.py
@@ -153,7 +153,7 @@ def align(
     fasta_reference = hail_batch.fasta_res_group(batch_instance)
 
     # now finish as a CRAM
-    align_cmd += f""" samtools view --write-index -@{nthreads} \\
+    align_cmd += f""" | samtools view --write-index -@{nthreads} \\
         -T {fasta_reference.base} \\
         -O cram,version=3.0 \\
         -o {merge_or_align_j.output_cram.cram}

--- a/src/align_genotype/jobs/align.py
+++ b/src/align_genotype/jobs/align.py
@@ -128,7 +128,7 @@ def align(
         stdout_is_sorted = True
 
     # add in dupblaster streaming
-    align_cmd += f' | dupblaster --stats {merge_or_align_j.stats} | '
+    align_cmd += f' | dupblaster --stats stats.tsv | '
 
     # get number of threads for VM tempalte
     vm_resources = resources.HIGHMEM.request_resources(
@@ -164,6 +164,7 @@ def align(
     """
 
     merge_or_align_j.command(hail_batch.command(align_cmd, monitor_space=True))
+    merge_or_align_j.command(f'mv stats.tsv {merge_or_align_j.stats}')
 
     batch_instance.write_output(merge_or_align_j.stats, markdup_metrics_path)
     batch_instance.write_output(merge_or_align_j.output_cram, str(output_path.with_suffix('')))

--- a/src/align_genotype/jobs/align.py
+++ b/src/align_genotype/jobs/align.py
@@ -2,16 +2,13 @@
 FASTQ/BAM/CRAM -> CRAM: create Hail Batch jobs for (re-)alignment.
 """
 
-import logging
 import os.path
 from textwrap import dedent
 from typing import cast
 
-from cpg_flow import filetypes, resources, targets, utils
-from cpg_utils import Path, config, hail_batch, to_path
+from cpg_flow import filetypes, resources, targets
+from cpg_utils import Path, config, hail_batch
 from hailtop.batch.job import BashJob
-
-from align_genotype.jobs import picard
 
 DRAGMAP_INDEX_FILES = ['hash_table.cfg.bin', 'hash_table.cmp', 'reference.bin']
 
@@ -20,7 +17,6 @@ def align(
     sequencing_group: targets.SequencingGroup,
     job_attrs: dict,
     output_path: Path,
-    sorted_bam_path: str,
     markdup_metrics_path: str,
 ) -> list[BashJob]:
     """
@@ -39,7 +35,7 @@ def align(
 
     - if the sorted bam can be reused, skip the alignment job(s) and go straight to markdup.
 
-    - the markdup tool is picard, deduplication is submitted in a separate job.
+    - the markdup tool is dupblaster, run in stream in the same job.
 
     - nthreads can be set for smaller test runs on toy instance, so the job
     doesn't take entire 32-cpu/64-threaded instance.
@@ -65,20 +61,7 @@ def align(
     sharded_align_jobs = []
     sorted_bams = []
 
-    if utils.can_reuse(sorted_bam_path):
-        logging.info(f'{sequencing_group.id} :: Re-using sorted BAM: {sorted_bam_path}')
-        # It's necessary to create this merge_or_align_j object to pass it to finalise_alignment,
-        # and to declare the sorted_bam_path as a resource, so it can be written to the checkpoint.
-        job_attrs = (job_attrs or {}) | {'label': 'Reusing sorted bam', 'tool': 'Reusing sorted bam'}
-        merge_or_align_j = batch_instance.new_bash_job('Reusing sorted bam', job_attrs or {})
-        merge_or_align_j.image(config.config_retrieve(['workflow', 'driver_image']))
-        merge_or_align_j.sorted_bam = batch_instance.read_input(sorted_bam_path)
-        jobs.append(merge_or_align_j)
-        # The align_cmd and other parameters are not used but are necessary to pass to finalise_alignment.
-        align_cmd = ''
-        stdout_is_sorted = True
-
-    elif not sharded:  # Just running one alignment job
+    if not sharded:  # Just running one alignment job
         if isinstance(alignment_input, filetypes.FastqPairs):
             alignment_input = alignment_input[0]
         align_j, align_cmd = _align_one(
@@ -124,7 +107,7 @@ def align(
                 sharded_align_jobs.append(j)
 
         merge_j = batch_instance.new_bash_job('Merge BAMs', (job_attrs or {}) | {'tool': 'samtools_merge'})
-        merge_j.image(config.config_retrieve(['images', 'samtools']))
+        merge_j.image(config.config_retrieve(['workflow', 'driver_image']))
 
         nthreads = resources.STANDARD.set_resources(
             j=merge_j,
@@ -144,17 +127,47 @@ def align(
         merge_or_align_j = merge_j
         stdout_is_sorted = True
 
-    jobs.append(
-        finalise_alignment(
-            align_cmd=align_cmd,
-            stdout_is_sorted=stdout_is_sorted,
-            job=merge_or_align_j,
-            job_attrs=job_attrs,
-            output_path=output_path,
-            sorted_bam_path=sorted_bam_path,
-            out_markdup_metrics_path=markdup_metrics_path,
+    # add in dupblaster streaming
+    align_cmd += f' | dupblaster --stats {merge_or_align_j.stats} | '
+
+    batch_instance.write_output(merge_or_align_j.stats, markdup_metrics_path)
+
+    # get number of threads for VM tempalte
+    vm_resources = resources.HIGHMEM.request_resources(
+        nthreads=config.config_retrieve(
+            ['workflow', 'align_threads'],
+            resources.HIGHMEM.max_threads(),
         )
     )
+
+    nthreads = vm_resources.get_nthreads() - 1
+
+    vm_resources.set_to_job(merge_or_align_j)
+
+    # use a resource group for writes
+    merge_or_align_j.declare_resource_group(
+        output_cram={
+            'cram': '{root}.cram',
+            'cram.crai': '{root}.cram.crai',
+        },
+    )
+
+    # pipe through a sort, or don't
+    if not stdout_is_sorted:
+        align_cmd += f' {sort_cmd(nthreads)}'
+
+    fasta_reference = hail_batch.fasta_res_group(batch_instance)
+
+    # now finish as a CRAM
+    align_cmd += f""" samtools view --write-index -@{nthreads - 1} \\
+        -T {fasta_reference.base} \\
+        -O cram,version=3.0 \\
+        -o {merge_or_align_j.output_cram.cram}
+    """
+
+    merge_or_align_j.command(hail_batch.command(align_cmd, monitor_space=True))
+
+    batch_instance.write_output(merge_or_align_j.output_cram, str(output_path.with_suffix('')))
 
     return jobs
 
@@ -367,51 +380,3 @@ def sort_cmd(requested_nthreads: int) -> str:
     | samtools sort -@{min(nthreads, 6) - 1} -T $BATCH_TMPDIR/samtools-sort-tmp -Obam
     """,
     ).strip()
-
-
-def finalise_alignment(
-    align_cmd: str,
-    stdout_is_sorted: bool,
-    job: BashJob,
-    job_attrs: dict,
-    output_path: Path,
-    sorted_bam_path: str,
-    out_markdup_metrics_path: str,
-) -> BashJob:
-    """
-    For `MarkDupTool.PICARD`, creates a new job, as Picard can't read from stdin.
-    """
-
-    batch_instance = hail_batch.get_batch()
-
-    nthreads = resources.STANDARD.request_resources(
-        nthreads=config.config_retrieve(
-            ['workflow', 'align_threads'],
-            resources.STANDARD.max_threads(),
-        )
-    ).get_nthreads()
-
-    align_cmd = align_cmd.strip()
-    if not stdout_is_sorted:
-        align_cmd += f' {sort_cmd(nthreads)}'
-    align_cmd += f' > {job.sorted_bam}'
-
-    if not utils.can_reuse(sorted_bam_path):
-        job.command(hail_batch.command(align_cmd, monitor_space=True))
-
-    if (
-        sorted_bam_path
-        and not to_path(sorted_bam_path).exists()
-        and config.config_retrieve(['workflow', 'checkpoint_sorted_bam'], False)
-    ):
-        # Write the sorted BAM to the checkpoint if it doesn't already exist and the config is set
-        logging.info(f'Will write sorted bam to checkpoint: {sorted_bam_path}')
-        batch_instance.write_output(job.sorted_bam, sorted_bam_path)
-
-    return picard.markdup(
-        batch_instance=batch_instance,
-        sorted_bam=job.sorted_bam,
-        output_path=output_path,
-        out_markdup_metrics_path=out_markdup_metrics_path,
-        job_attrs=job_attrs,
-    )

--- a/src/align_genotype/jobs/picard.py
+++ b/src/align_genotype/jobs/picard.py
@@ -2,82 +2,9 @@
 Create Hail Batch jobs to run Picard tools (marking duplicates, QC).
 """
 
-import hailtop.batch as hb
 from cpg_flow import resources
 from cpg_utils import Path, config, hail_batch
 from hailtop.batch.job import BashJob
-
-
-def markdup(
-    batch_instance: hb.Batch,
-    sorted_bam: hb.Resource,
-    job_attrs: dict,
-    output_path: Path,
-    out_markdup_metrics_path: str,
-) -> BashJob:
-    """
-    Make job that runs Picard MarkDuplicates and converts the result to CRAM.
-    """
-    job = batch_instance.new_bash_job(
-        f'MarkDuplicates {"mito" if "mito" in str(output_path) else ""}',
-        attributes=job_attrs | {'tool': 'picard_MarkDuplicates'},
-    )
-
-    job.image(config.config_retrieve(['images', 'picard']))
-    # allow markduplicates job to be non-spot (for particularly large & unlucky sequencing groups)
-    job.spot(config.config_retrieve(['workflow', 'picard_spot'], True))
-
-    # check for a memory override for impossible sequencing groups
-    # if RAM is overridden, update the memory resource setting
-    # check for a storage override for unreasonably large sequencing groups
-    resource = resources.HIGHMEM.request_resources(
-        ncpu=4,
-        mem_gb=config.config_retrieve(['workflow', 'picard_mem_gb'], None),
-        storage_gb=config.config_retrieve(['workflow', 'picard_storage_gb']),
-    )
-
-    resource.set_to_job(job)
-
-    job.declare_resource_group(
-        output_cram={
-            'cram': '{root}.cram',
-            'cram.crai': '{root}.cram.crai',
-        },
-    )
-
-    fasta_reference = hail_batch.fasta_res_group(batch_instance)
-    seq_type = config.config_retrieve(['workflow', 'sequencing_type'])
-    overhead_gb = config.config_retrieve(['workflow', f'picard_markdup_{seq_type}_overhead_gb'], 1.0)
-
-    max_records_in_ram_cmd = ''
-    if max_records_in_ram := config.config_retrieve(['workflow', 'picard_markdup_max_records_in_ram'], None):
-        max_records_in_ram_cmd = f'--MAX_RECORDS_IN_RAM {max_records_in_ram}'
-
-    cmd = f"""
-    picard {resource.java_mem_options(overhead_gb=overhead_gb)} MarkDuplicates \\
-    -I {sorted_bam} -O {job.temp_bam} -M {job.markdup_metrics} \\
-    --TMP_DIR $(dirname {job.output_cram.cram})/picard-tmp \\
-    --ASSUME_SORT_ORDER coordinate {max_records_in_ram_cmd}
-    echo "MarkDuplicates finished successfully"
-
-    rm {sorted_bam}
-
-    samtools view --write-index -@{resource.get_nthreads() - 1} \\
-    -T {fasta_reference.base} \\
-    -O cram,version=3.0 \\
-    -o {job.output_cram.cram} \\
-    {job.temp_bam}
-    echo "samtools view finished successfully"
-    """
-    job.command(hail_batch.command(cmd, monitor_space=True))
-
-    batch_instance.write_output(job.output_cram, str(output_path.with_suffix('')))
-    batch_instance.write_output(
-        job.markdup_metrics,
-        out_markdup_metrics_path,
-    )
-
-    return job
 
 
 def generate_intervals(output_paths: list[Path], job_attrs: dict[str, str]) -> BashJob:

--- a/src/align_genotype/stages.py
+++ b/src/align_genotype/stages.py
@@ -51,9 +51,6 @@ class AlignWithDragmap(stage.SequencingGroupStage):
         cram_path = sequencing_group.cram if sequencing_group.cram else sequencing_group.make_cram_path()
         return {
             'cram': cram_path.path,
-            'sorted_bam': str(
-                sequencing_group.dataset.prefix(category='tmp') / 'align' / f'{sequencing_group.id}.sorted.bam'
-            ),
             'markdup': str(
                 sequencing_group.dataset.prefix()
                 / 'qc'
@@ -73,7 +70,6 @@ class AlignWithDragmap(stage.SequencingGroupStage):
             sequencing_group=sequencing_group,
             job_attrs=self.get_job_attrs(sequencing_group),
             output_path=outputs['cram'],
-            sorted_bam_path=outputs['sorted_bam'],
             markdup_metrics_path=outputs['markdup'],
         )
 

--- a/src/align_genotype/stages.py
+++ b/src/align_genotype/stages.py
@@ -1,7 +1,3 @@
-"""
-Alignment and genotyping... oof. Where to start.
-"""
-
 from cpg_flow import stage, targets, workflow
 from cpg_utils import Path, config, to_path
 
@@ -24,14 +20,10 @@ class GenerateIntervalsOnce(stage.MultiCohortStage):
         prefix = multicohort.analysis_dataset.prefix() / 'genotype' / sequencing_type / f'{scatter_count}_intervals'
         return {'intervals': [prefix / to_path(f'{idx}.interval_list') for idx in range(1, scatter_count + 1)]}
 
-    def queue_jobs(
-        self,
-        multicohort: targets.MultiCohort,
-        inputs: stage.StageInput,  # noqa: ARG002
-    ) -> stage.StageOutput:
-        outputs = self.expected_outputs(multicohort)
-        job = generate_intervals(outputs['intervals'], self.get_job_attrs(multicohort))
-        return self.make_outputs(multicohort, jobs=job, data=outputs)
+    def queue_jobs(self, mc: targets.MultiCohort, inputs: stage.StageInput) -> stage.StageOutput:  # noqa: ARG002
+        outputs = self.expected_outputs(mc)
+        job = generate_intervals(outputs['intervals'], self.get_job_attrs(mc))
+        return self.make_outputs(mc, jobs=job, data=outputs)
 
 
 @stage.stage(
@@ -39,25 +31,12 @@ class GenerateIntervalsOnce(stage.MultiCohortStage):
     analysis_keys=['cram'],
 )
 class AlignWithDragmap(stage.SequencingGroupStage):
-    """
-    This is a generic stage that runs a bash command.
-    """
-
     def expected_outputs(self, sequencing_group: targets.SequencingGroup) -> dict[str, Path | str]:
-        """
-        n.b. markduplicates-metrics are a String here so their existence isn't detected during DAG assembly.
-        This means we will not accidentally restart alignment where this optional accessory file doesn't exist.
-        """
+        """At time of writing markdup-metrics has been removed."""
         cram_path = sequencing_group.cram if sequencing_group.cram else sequencing_group.make_cram_path()
-        return {
-            'cram': cram_path.path,
-        }
+        return {'cram': cram_path.path}
 
     def queue_jobs(self, sequencing_group: targets.SequencingGroup, inputs: stage.StageInput) -> stage.StageOutput:  # noqa: ARG002
-        """
-        This is where we generate jobs for this stage.
-        """
-
         outputs = self.expected_outputs(sequencing_group)
 
         jobs = align(
@@ -66,7 +45,6 @@ class AlignWithDragmap(stage.SequencingGroupStage):
             output_path=outputs['cram'],
         )
 
-        # return the jobs and outputs
         return self.make_outputs(target=sequencing_group, data=outputs, jobs=jobs)
 
 
@@ -80,16 +58,11 @@ class GenotypeWithGatk(stage.SequencingGroupStage):
     """
 
     def expected_outputs(self, sequencing_group: targets.SequencingGroup) -> Path:
-        """
-        Generate a GVCF and corresponding TBI index.
-        """
+        """Generate a GVCF and corresponding TBI index."""
         gvcf = sequencing_group.gvcf or sequencing_group.make_gvcf_path()
         return gvcf.path
 
     def queue_jobs(self, sequencing_group: targets.SequencingGroup, inputs: stage.StageInput) -> stage.StageOutput:
-        """
-        Use function from the jobs module
-        """
 
         output = self.expected_outputs(sequencing_group)
 
@@ -334,7 +307,12 @@ class RunVntyper(stage.SequencingGroupStage):
         return self.make_outputs(sequencing_group, data=outputs, jobs=jobs)
 
 
-@stage.stage(required_stages=[RunVntyper], analysis_keys=['html'], analysis_type='web', forced=True)
+@stage.stage(
+    required_stages=[RunVntyper],
+    analysis_keys=['html'],
+    analysis_type='web',
+    forced=True,
+)
 class VntyperIndexPage(stage.DatasetStage):
     def expected_outputs(self, dataset: targets.Dataset) -> dict[str, Path]:
         web_bucket = dataset.web_prefix() / 'vntyper'
@@ -346,6 +324,7 @@ class VntyperIndexPage(stage.DatasetStage):
         # only run this for a subset of projects, but for all SG IDs in those projects
         if dataset.name not in config.config_retrieve(['vntyper', 'vntyper_projects']):
             return self.make_outputs(dataset, data=None, jobs=None)
+
         output = self.expected_outputs(dataset)
         job = vntyper_index_job(dataset=dataset.name, output=output['html'])
         return self.make_outputs(dataset, data=output, jobs=job)

--- a/src/align_genotype/stages.py
+++ b/src/align_genotype/stages.py
@@ -51,12 +51,6 @@ class AlignWithDragmap(stage.SequencingGroupStage):
         cram_path = sequencing_group.cram if sequencing_group.cram else sequencing_group.make_cram_path()
         return {
             'cram': cram_path.path,
-            'markdup': str(
-                sequencing_group.dataset.prefix()
-                / 'qc'
-                / 'markduplicates_metrics'
-                / f'{sequencing_group.id}.markduplicates-metrics'
-            ),
         }
 
     def queue_jobs(self, sequencing_group: targets.SequencingGroup, inputs: stage.StageInput) -> stage.StageOutput:  # noqa: ARG002
@@ -70,7 +64,6 @@ class AlignWithDragmap(stage.SequencingGroupStage):
             sequencing_group=sequencing_group,
             job_attrs=self.get_job_attrs(sequencing_group),
             output_path=outputs['cram'],
-            markdup_metrics_path=outputs['markdup'],
         )
 
         # return the jobs and outputs


### PR DESCRIPTION
# Purpose

  - Picard is terribly slow for making duplicates, and the multi-job, passed-around-command situation we have on main is not ideal to work with
  - Closes #33 
  - Linked to https://github.com/populationgenomics/images/pull/311

## Proposed Changes

  - installs dupblaster and samtools (1.23.1) in the docker image. This replaces the apt-get samtools install which was only v.1.11.1 (_old_). Installs **[dupblaster](https://github.com/fulcrumgenomics/dupblaster)**, via cargo. Crucially both these installs are in a compilation build layer, which means the final image only needs the executables, not the build libraries/Cargo.
  - rips out picard for duplicate marking, instead using in-stream dupblaster
  - dupblaster is set to run with `--stats`, which should mean we still get a picard-compatible metrics file
  - removes the checkpointed bam (and related config variable)
  - removes some other config variables related to markdup

This needs thorough validation. We'll need to see a few runs, confirming that gVCFs are identical, and CRAMs are functionally equivalent. We'd be happy with minor differences in exchange for a massive performance gain, but won't tolerate substantial regressions. 

## Test Runs
1. https://batch.hail.populationgenomics.org.au/batches/1133593 - compared to main-run [here](https://batch.hail.populationgenomics.org.au/batches/1133427?criterion-select=name&q=name+%3D%7E+perth-neuro%2F)

## Checklist

- [ ] Related GitHub Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
