### PR TITLE
First attempt at a recovery script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN apt-get update && \
     rm -r /var/cache/apt/*
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.5.0
+ENV VERSION=0.5.1
 
 WORKDIR /align_genotype
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This single-sample workflow has a dedicated entrypoint, and can be operated thro
 
 ```bash
 analysis-runner --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.5.0-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.5.1-1 \
     --config src/align_genotype/config_template.toml \
     --dataset seqr \
     --description 'Single-Sample data generation' \
@@ -36,7 +36,7 @@ This Dataset-level workflow can be run in a similar way, but with a different en
 
 ```bash
 analysis-runner --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.5.0-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.5.1-1 \
     --config src/align_genotype/config_template.toml \
     --dataset seqr \
     --description 'Dataset-Level QC workflow' \
@@ -49,7 +49,7 @@ A third workflow is available to run VNtyper on a set of samples, which can be u
 
 ```bash
 analysis-runner --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.5.0-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.5.1-1 \
     --config src/align_genotype/config_template.toml \
     --config src/align_genotype/vntyper.toml \
     --dataset seqr \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='Dragmap align & genotype workflow, using CPG-Flow'
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.5.0"
+version="0.5.1"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -105,7 +105,7 @@ hail = ["hail", "hailtop"]
 "src/align_genotype/jobs/somalier.py" = ["C901", "PLR0912", "PLR0913", "PLR0915"]  # ignore complexity for this script
 
 [tool.bumpversion]
-current_version = "0.5.0"
+current_version = "0.5.1"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/align_genotype/jobs/align.py
+++ b/src/align_genotype/jobs/align.py
@@ -359,7 +359,7 @@ def dedup_sort_cmd(nthreads: int, stats_path: str) -> str:
     Create command that deduplicates a name-sorted (RG-ordered) stream with dupblaster,
     writing duplication stats to `stats_path`, then coordinate-sorts the result.
     """
-    cmd = f'| dupblaster --stats {stats_path} --tmp-dir $BATCH_TMPDIR '
+    cmd = f'| dupblaster --stats {stats_path} '
     cmd += f'| samtools sort -@{min(nthreads, 6) - 1} -T $BATCH_TMPDIR/samtools-dd-tmp -Obam '
     return cmd
 

--- a/src/align_genotype/jobs/align.py
+++ b/src/align_genotype/jobs/align.py
@@ -88,7 +88,7 @@ def align(
                 )
                 if shard_fifo_epilogue:
                     cmd += f'\n{shard_fifo_epilogue}'
-                j.command(hail_batch.command(cmd, monitor_space=True))
+                j.command(cmd)
                 sorted_bams.append(j.sorted_bam)
                 sharded_align_jobs.append(j)
 
@@ -106,7 +106,7 @@ def align(
                 # must see the full RG-ordered read stream to catch cross-shard duplicates.
                 if shard_fifo_epilogue:
                     cmd += f'\n{shard_fifo_epilogue}'
-                j.command(hail_batch.command(cmd, monitor_space=True))
+                j.command(cmd)
                 sorted_bams.append(j.sorted_bam)
                 sharded_align_jobs.append(j)
 
@@ -158,7 +158,7 @@ def storage_for_align_job(alignment_input: filetypes.AlignmentInput) -> int:
     storage_gb = 100
 
     if config.config_retrieve(['workflow', 'sequencing_type']) == 'genome':
-        storage_gb = 200
+        storage_gb = 400
 
         # More disk is needed for FASTQ or BAM inputs than for realignment from CRAM
         if isinstance(alignment_input, filetypes.FastqPair | filetypes.FastqPairs | filetypes.BamPath):
@@ -359,7 +359,7 @@ def dedup_sort_cmd(nthreads: int, stats_path: str) -> str:
     Create command that deduplicates a name-sorted (RG-ordered) stream with dupblaster,
     writing duplication stats to `stats_path`, then coordinate-sorts the result.
     """
-    cmd = f'| dupblaster --stats {stats_path} --single-end-strategy picard-exact --tmp-dir $BATCH_TMPDIR '
+    cmd = f'| dupblaster --stats {stats_path} --tmp-dir $BATCH_TMPDIR '
     cmd += f'| samtools sort -@{min(nthreads, 6) - 1} -T $BATCH_TMPDIR/samtools-dd-tmp -Obam '
     return cmd
 
@@ -405,7 +405,7 @@ def finalise_alignment(
         # the aligner and the dedup/sort/view stages consuming its stdout
         align_cmd += f'\n{fifo_epilogue}'
 
-    job.command(hail_batch.command(align_cmd, monitor_space=True))
+    job.command(align_cmd)
 
     # persist the duplication stats produced by dupblaster and the indexed CRAM
     batch_instance.write_output(job.markdup_metrics, out_markdup_metrics_path)

--- a/src/align_genotype/scripts/alignment_recovery.py
+++ b/src/align_genotype/scripts/alignment_recovery.py
@@ -12,7 +12,7 @@ The BAM shards MUST be provided in the same order the pipeline emitted them (Ali
 Example:
     python alignment_recovery.py \\
         -s CPG1234 \\
-        -o gs://cpg-seqr-main/cram/CPG1234.cram \\
+        -o gs://cpg-dataset-main/cram/CPG1234.cram \\
         -p seqr \\
         -i gs://tmp-bucket/c2dfbe/Align_1_6_-P167e/sorted_bam \\
            gs://tmp-bucket/c2dfbe/Align_2_6_-qPVi8/sorted_bam \\

--- a/src/align_genotype/scripts/alignment_recovery.py
+++ b/src/align_genotype/scripts/alignment_recovery.py
@@ -58,7 +58,7 @@ def register_cram(output: str, sgid: str, dataset: str, stage: str, seq_type: st
     Create a completed `cram` analysis entry in Metamist. Runs inside the batch as a PythonJob that
     depends on the merge job, so registration only happens if the CRAM was produced successfully.
     """
-    from cpg_flow.metamist import Metamist
+    from cpg_flow.metamist import Metamist  # noqa: PLC0415
 
     Metamist().create_analysis(
         output=output,

--- a/src/align_genotype/scripts/alignment_recovery.py
+++ b/src/align_genotype/scripts/alignment_recovery.py
@@ -81,7 +81,7 @@ if __name__ == '__main__':
 
     fasta_reference = hail_batch.fasta_res_group(batch_instance)
 
-    nthreads = config.config_retrieve(['workflow', 'merge_threads'], 8)
+    nthreads = config.config_retrieve(['workflow', 'merge_threads'], 16)
 
     merge_job = batch_instance.new_bash_job(name=f'Merge BAMs for {args.sgid}', attributes={'tool': 'samtools_merge'})
     merge_job.image(config.config_retrieve(['workflow', 'driver_image']))

--- a/src/align_genotype/scripts/alignment_recovery.py
+++ b/src/align_genotype/scripts/alignment_recovery.py
@@ -14,12 +14,12 @@ Example:
         -s CPG1234 \\
         -o gs://cpg-seqr-main/cram/CPG1234.cram \\
         -p seqr \\
-        -i gs://cpg-seqr-main-tmp/batch-tmp/c2dfbe/Align_1_6_-P167e/sorted_bam \\
-           gs://cpg-seqr-main-tmp/batch-tmp/c2dfbe/Align_2_6_-qPVi8/sorted_bam \\
-           gs://cpg-seqr-main-tmp/batch-tmp/c2dfbe/Align_3_6_-tBItI/sorted_bam \\
-           gs://cpg-seqr-main-tmp/batch-tmp/c2dfbe/Align_4_6_-Slx2L/sorted_bam \\
-           gs://cpg-seqr-main-tmp/batch-tmp/c2dfbe/Align_5_6_-M1pXr/sorted_bam \\
-           gs://cpg-seqr-main-tmp/batch-tmp/c2dfbe/Align_6_6_-51gSX/sorted_bam
+        -i gs://tmp-bucket/c2dfbe/Align_1_6_-P167e/sorted_bam \\
+           gs://tmp-bucket/c2dfbe/Align_2_6_-qPVi8/sorted_bam \\
+           gs://tmp-bucket/c2dfbe/Align_3_6_-tBItI/sorted_bam \\
+           gs://tmp-bucket/c2dfbe/Align_4_6_-Slx2L/sorted_bam \\
+           gs://tmp-bucket/c2dfbe/Align_5_6_-M1pXr/sorted_bam \\
+           gs://tmp-bucket/c2dfbe/Align_6_6_-51gSX/sorted_bam
 """
 
 import argparse

--- a/src/align_genotype/scripts/alignment_recovery.py
+++ b/src/align_genotype/scripts/alignment_recovery.py
@@ -1,0 +1,125 @@
+"""
+The current alignment process can fail during merging, which leaves the workflow in limbo, having to
+repeat the (expensive) alignment of every shard from scratch.
+
+This script rescues those alignments: the per-shard name-sorted BAMs are usually still sitting in the
+batch tmp bucket, so we can pick up where the pipeline failed - merge them, deduplicate, coordinate-sort,
+and convert to a final CRAM - without re-running DRAGMAP.
+
+The BAM shards MUST be provided in the same order the pipeline emitted them (Align_1, Align_2, ...), as
+`samtools merge -n` relies on a consistent RG-ordered stream for dupblaster to catch cross-shard duplicates.
+
+Example:
+    python alignment_recovery.py \\
+        -s CPG1234 \\
+        -o gs://cpg-seqr-main/cram/CPG1234.cram \\
+        -p seqr \\
+        -i gs://cpg-seqr-main-tmp/batch-tmp/c2dfbe/Align_1_6_-P167e/sorted_bam \\
+           gs://cpg-seqr-main-tmp/batch-tmp/c2dfbe/Align_2_6_-qPVi8/sorted_bam \\
+           gs://cpg-seqr-main-tmp/batch-tmp/c2dfbe/Align_3_6_-tBItI/sorted_bam \\
+           gs://cpg-seqr-main-tmp/batch-tmp/c2dfbe/Align_4_6_-Slx2L/sorted_bam \\
+           gs://cpg-seqr-main-tmp/batch-tmp/c2dfbe/Align_5_6_-M1pXr/sorted_bam \\
+           gs://cpg-seqr-main-tmp/batch-tmp/c2dfbe/Align_6_6_-51gSX/sorted_bam
+"""
+
+import argparse
+
+from cpg_utils import config, hail_batch, to_path
+
+from align_genotype.jobs.align import dedup_sort_cmd
+
+
+def parser_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', '--sgid', type=str, required=True, help='Sequencing Group ID')
+    parser.add_argument('-o', '--out', type=str, required=True, help='Path to final CRAM')
+    parser.add_argument('-p', '--project', type=str, required=True, help='Project/dataset for registration')
+    parser.add_argument(
+        '-i',
+        '--input',
+        nargs='+',
+        type=str,
+        required=True,
+        help='Paths to the per-shard name-sorted BAMs, in shard order (Align_1, Align_2, ...)',
+    )
+    parser.add_argument('--stage', type=str, default='AlignWithDragmap', help='Stage name, recorded in Metamist meta')
+    parser.add_argument('--seq_type', type=str, default='genome', help='Sequencing Type')
+    parser.add_argument('--storage', type=int, default=400, help='Storage in GiB to use for merge/sort')
+    parser.add_argument(
+        '--no-register',
+        action='store_true',
+        help='Skip creating a Metamist analysis entry (only produce the CRAM)',
+    )
+    return parser.parse_args()
+
+
+def register_cram(output: str, sgid: str, dataset: str, stage: str, seq_type: str) -> None:
+    """
+    Create a completed `cram` analysis entry in Metamist. Runs inside the batch as a PythonJob that
+    depends on the merge job, so registration only happens if the CRAM was produced successfully.
+    """
+    from cpg_flow.metamist import Metamist
+
+    Metamist().create_analysis(
+        output=output,
+        type_='cram',
+        status='completed',
+        sequencing_group_ids=[sgid],
+        dataset=dataset,
+        meta={'stage': stage, 'sequencing_type': seq_type, 'source': 'alignment_recovery'},
+    )
+
+
+if __name__ == '__main__':
+    args = parser_args()
+
+    batch_instance = hail_batch.get_batch(name=f'Merge alignments for {args.sgid}')
+
+    # Read the BAM shards into the batch, preserving CLI order so `samtools merge -n` sees a
+    # consistent RG-ordered stream. The list comprehension keeps ordering 1:1 with args.input.
+    local_bams = [batch_instance.read_input(bam) for bam in args.input]
+
+    fasta_reference = hail_batch.fasta_res_group(batch_instance)
+
+    nthreads = config.config_retrieve(['workflow', 'merge_threads'], 8)
+
+    merge_job = batch_instance.new_bash_job(name=f'Merge BAMs for {args.sgid}', attributes={'tool': 'samtools_merge'})
+    merge_job.image(config.config_retrieve(['workflow', 'driver_image']))
+    merge_job.storage(f'{args.storage}GiB')
+    merge_job.cpu(nthreads)
+    merge_job.memory('highmem')
+    merge_job.declare_resource_group(
+        output_cram={
+            'cram': '{root}.cram',
+            'cram.crai': '{root}.cram.crai',
+        },
+    )
+
+    # Reproduce the pipeline's merge path exactly (see jobs/align.py):
+    #   1. name-order merge of the shards -> RG-ordered stream
+    #   2. dupblaster + coordinate-sort   -> catches cross-shard duplicates
+    #   4. samtools view                  -> indexed CRAM (v3.0) written to GCS
+    bam_string = ' '.join(map(str, local_bams))
+    CMD = (
+        f'samtools merge -n -@5 - {bam_string} '
+        f'{dedup_sort_cmd(nthreads, merge_job.markdup_metrics)} '
+        f'| samtools view --write-index -@5 '
+        f'-T {fasta_reference.base} -O cram,version=3.0 -o {merge_job.output_cram.cram} -'
+    )
+    merge_job.command(CMD)
+
+    # write_output takes the resource-group root (no suffix); .cram / .cram.crai are appended
+    out_path = to_path(args.out)
+    batch_instance.write_output(merge_job.output_cram, str(out_path.with_suffix('')))
+    batch_instance.write_output(
+        merge_job.markdup_metrics,
+        f'{out_path.with_suffix("")}.markduplicates-metrics',
+    )
+
+    if not args.no_register:
+        register_job = batch_instance.new_python_job(name=f'Register CRAM for {args.sgid}')
+        register_job.image(config.config_retrieve(['workflow', 'driver_image']))
+        register_job.depends_on(merge_job)
+        register_job.call(register_cram, str(args.out), args.sgid, args.project, args.stage, args.seq_type)
+
+    batch_instance.run(wait=False)


### PR DESCRIPTION
# Purpose

The alignment workflow has a few core issues:

- if the merging step fails, there is no clean recovery path (checkpoint removed in dupblaster change)
- if the merging step fails, the VM doesn't close down, possibly due to backgrounded `du` task still running
- default storage has been insufficient for merging tasks
- the orphaned reads in dupblaster flow have been crashing the workflow

## Proposed Changes

  - remove the hail_batch.command wrapper
  - create a new script to try and rescue failed runs without requiring realignment
  - remove the `--single-strand picard-exact` parameter, settling for strand-aware, which should be fine for our paired end work