### PR TITLE
Add pipefail command to all align jobs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN apt-get update && \
     rm -r /var/cache/apt/*
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.5.1
+ENV VERSION=0.5.2
 
 WORKDIR /align_genotype
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This single-sample workflow has a dedicated entrypoint, and can be operated thro
 
 ```bash
 analysis-runner --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.5.1-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.5.2-1 \
     --config src/align_genotype/config_template.toml \
     --dataset seqr \
     --description 'Single-Sample data generation' \
@@ -36,7 +36,7 @@ This Dataset-level workflow can be run in a similar way, but with a different en
 
 ```bash
 analysis-runner --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.5.1-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.5.2-1 \
     --config src/align_genotype/config_template.toml \
     --dataset seqr \
     --description 'Dataset-Level QC workflow' \
@@ -49,7 +49,7 @@ A third workflow is available to run VNtyper on a set of samples, which can be u
 
 ```bash
 analysis-runner --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.5.1-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.5.2-1 \
     --config src/align_genotype/config_template.toml \
     --config src/align_genotype/vntyper.toml \
     --dataset seqr \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='Dragmap align & genotype workflow, using CPG-Flow'
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.5.1"
+version="0.5.2"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -105,7 +105,7 @@ hail = ["hail", "hailtop"]
 "src/align_genotype/jobs/somalier.py" = ["C901", "PLR0912", "PLR0913", "PLR0915"]  # ignore complexity for this script
 
 [tool.bumpversion]
-current_version = "0.5.1"
+current_version = "0.5.2"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/align_genotype/jobs/align.py
+++ b/src/align_genotype/jobs/align.py
@@ -124,6 +124,7 @@ def align(
         # Merge the name-sorted shards in name order, deduplicate the combined RG-ordered
         # stream with dupblaster, then coordinate-sort the result for downstream tools.
         align_cmd = f"""\
+        set -euo pipefail
         samtools merge -n -@{min(nthreads, 6) - 1} - {' '.join(map(str, sorted_bams))} \
         {dedup_sort_cmd(nthreads, merge_j.markdup_metrics)}
         """.strip()
@@ -204,6 +205,7 @@ def _align_one(
         config.config_retrieve(['workflow', 'align_memory'], 'highmem')
     ).image(config.config_retrieve(['images', 'dragmap']))
 
+    pipefail_cmd = 'set -euo pipefail'
     sort_index_input_cmd = ''
 
     # 2022-07-22 mfranklin:
@@ -270,6 +272,7 @@ def _align_one(
         # Need file names to end with ".gz" for BWA or DRAGMAP to parse correctly:
         prepare_fastq_cmd = dedent(
             f"""
+            set -euo pipefail
             tar -xf {fqo_resource_group.reference} -C $BATCH_TMPDIR
             orad -c --ora-reference $BATCH_TMPDIR/oradata_homo_sapiens {fqo_resource_group.r1} > {r1_param}
             rm {fqo_resource_group.r1}
@@ -286,6 +289,7 @@ def _align_one(
         # Need file names to end with ".gz" for BWA or DRAGMAP to parse correctly:
         prepare_fastq_cmd = dedent(
             f"""\
+        set -euo pipefail
         mv {fastq_pair.r1} {r1_param}
         mv {fastq_pair.r2} {r2_param}
         """,
@@ -342,7 +346,7 @@ def _align_one(
         ).strip()
 
         # Now prepare command
-        cmd = '\n'.join([sort_index_input_cmd, *fifo_pre, cmd])
+        cmd = '\n'.join([pipefail_cmd, sort_index_input_cmd, *fifo_pre, cmd])
     return job, cmd, fifo_epilogue
 
 

--- a/src/align_genotype/jobs/align.py
+++ b/src/align_genotype/jobs/align.py
@@ -11,6 +11,7 @@ from cpg_utils import Path, config, hail_batch
 from hailtop.batch.job import BashJob
 
 DRAGMAP_INDEX_FILES = ['hash_table.cfg.bin', 'hash_table.cmp', 'reference.bin']
+PIPEFAIL = 'set -euo pipefail'
 
 
 def align(
@@ -124,7 +125,7 @@ def align(
         # Merge the name-sorted shards in name order, deduplicate the combined RG-ordered
         # stream with dupblaster, then coordinate-sort the result for downstream tools.
         align_cmd = f"""\
-        set -euo pipefail
+        {PIPEFAIL}
         samtools merge -n -@{min(nthreads, 6) - 1} - {' '.join(map(str, sorted_bams))} \
         {dedup_sort_cmd(nthreads, merge_j.markdup_metrics)}
         """.strip()
@@ -205,7 +206,6 @@ def _align_one(
         config.config_retrieve(['workflow', 'align_memory'], 'highmem')
     ).image(config.config_retrieve(['images', 'dragmap']))
 
-    pipefail_cmd = 'set -euo pipefail'
     sort_index_input_cmd = ''
 
     # 2022-07-22 mfranklin:
@@ -272,7 +272,7 @@ def _align_one(
         # Need file names to end with ".gz" for BWA or DRAGMAP to parse correctly:
         prepare_fastq_cmd = dedent(
             f"""
-            {pipefail_cmd}
+            {PIPEFAIL}
             tar -xf {fqo_resource_group.reference} -C $BATCH_TMPDIR
             orad -c --ora-reference $BATCH_TMPDIR/oradata_homo_sapiens {fqo_resource_group.r1} > {r1_param}
             rm {fqo_resource_group.r1}
@@ -289,7 +289,7 @@ def _align_one(
         # Need file names to end with ".gz" for BWA or DRAGMAP to parse correctly:
         prepare_fastq_cmd = dedent(
             f"""\
-        {pipefail_cmd}
+        {PIPEFAIL}
         mv {fastq_pair.r1} {r1_param}
         mv {fastq_pair.r2} {r2_param}
         """,
@@ -346,7 +346,7 @@ def _align_one(
         ).strip()
 
         # Now prepare command
-        cmd = '\n'.join([pipefail_cmd, sort_index_input_cmd, *fifo_pre, cmd])
+        cmd = '\n'.join([PIPEFAIL, sort_index_input_cmd, *fifo_pre, cmd])
     return job, cmd, fifo_epilogue
 
 

--- a/src/align_genotype/jobs/align.py
+++ b/src/align_genotype/jobs/align.py
@@ -272,7 +272,7 @@ def _align_one(
         # Need file names to end with ".gz" for BWA or DRAGMAP to parse correctly:
         prepare_fastq_cmd = dedent(
             f"""
-            set -euo pipefail
+            {pipefail_cmd}
             tar -xf {fqo_resource_group.reference} -C $BATCH_TMPDIR
             orad -c --ora-reference $BATCH_TMPDIR/oradata_homo_sapiens {fqo_resource_group.r1} > {r1_param}
             rm {fqo_resource_group.r1}
@@ -289,7 +289,7 @@ def _align_one(
         # Need file names to end with ".gz" for BWA or DRAGMAP to parse correctly:
         prepare_fastq_cmd = dedent(
             f"""\
-        set -euo pipefail
+        {pipefail_cmd}
         mv {fastq_pair.r1} {r1_param}
         mv {fastq_pair.r2} {r2_param}
         """,

--- a/src/align_genotype/scripts/alignment_recovery.py
+++ b/src/align_genotype/scripts/alignment_recovery.py
@@ -26,7 +26,7 @@ import argparse
 
 from cpg_utils import config, hail_batch, to_path
 
-from align_genotype.jobs.align import dedup_sort_cmd
+from align_genotype.jobs.align import PIPEFAIL, dedup_sort_cmd
 
 
 def parser_args() -> argparse.Namespace:
@@ -101,6 +101,7 @@ if __name__ == '__main__':
     #   4. samtools view                  -> indexed CRAM (v3.0) written to GCS
     bam_string = ' '.join(map(str, local_bams))
     CMD = (
+        f'{PIPEFAIL} \n'
         f'samtools merge -n -@5 - {bam_string} '
         f'{dedup_sort_cmd(nthreads, merge_job.markdup_metrics)} '
         f'| samtools view --write-index -@5 '


### PR DESCRIPTION
# Purpose

  - See https://batch.hail.populationgenomics.org.au/batches/1134323/jobs/3
  - due to the piped command chain, a failure in the middle of a run-on command leads to a truncated file appearing as a success

## Proposed Changes

  - adds `set -euo pipefail` to all jobs in the alignment flow
  - For CRAM/BAM this is inserted during the join which builds the final command
  - For FQ/ORA this is inserted into the first command
  - For the merge job, this is inserted prior to the first command

## Checklist

- [ ] Related GitHub Issue created
- [ ] Tests covering new change
- [x] Linting checks pass
