### PR TITLE
Resolve double dupblaster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN apt-get update && \
     rm -r /var/cache/apt/*
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.5.2
+ENV VERSION=0.5.3
 
 WORKDIR /align_genotype
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This single-sample workflow has a dedicated entrypoint, and can be operated thro
 
 ```bash
 analysis-runner --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.5.2-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.5.3-1 \
     --config src/align_genotype/config_template.toml \
     --dataset seqr \
     --description 'Single-Sample data generation' \
@@ -36,7 +36,7 @@ This Dataset-level workflow can be run in a similar way, but with a different en
 
 ```bash
 analysis-runner --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.5.2-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.5.3-1 \
     --config src/align_genotype/config_template.toml \
     --dataset seqr \
     --description 'Dataset-Level QC workflow' \
@@ -49,7 +49,7 @@ A third workflow is available to run VNtyper on a set of samples, which can be u
 
 ```bash
 analysis-runner --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.5.2-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.5.3-1 \
     --config src/align_genotype/config_template.toml \
     --config src/align_genotype/vntyper.toml \
     --dataset seqr \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='Dragmap align & genotype workflow, using CPG-Flow'
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.5.2"
+version="0.5.3"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -105,7 +105,7 @@ hail = ["hail", "hailtop"]
 "src/align_genotype/jobs/somalier.py" = ["C901", "PLR0912", "PLR0913", "PLR0915"]  # ignore complexity for this script
 
 [tool.bumpversion]
-current_version = "0.5.2"
+current_version = "0.5.3"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/align_genotype/jobs/align.py
+++ b/src/align_genotype/jobs/align.py
@@ -127,7 +127,6 @@ def align(
         align_cmd = f"""\
         {PIPEFAIL}
         samtools merge -n -@{min(nthreads, 6) - 1} - {' '.join(map(str, sorted_bams))} \
-        {dedup_sort_cmd(nthreads, merge_j.markdup_metrics)}
         """.strip()
         jobs.extend(sharded_align_jobs)
         jobs.append(merge_j)


### PR DESCRIPTION
# Purpose

  - Pipeline breaks when multiple VCFs require merging - `dupblaster > samtools > dupblaster > samtools` runs in the command pipe

## Proposed Changes

  - Remove the explicit dupblaster call after `samtools merge`, it's re-run in finalise_alignment for all flows
