### PR TITLE
Terminate jobs with no storage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN apt-get update && \
     rm -r /var/cache/apt/*
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.5.3
+ENV VERSION=0.5.4
 
 WORKDIR /align_genotype
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This single-sample workflow has a dedicated entrypoint, and can be operated thro
 
 ```bash
 analysis-runner --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.5.3-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.5.4-1 \
     --config src/align_genotype/config_template.toml \
     --dataset seqr \
     --description 'Single-Sample data generation' \
@@ -36,7 +36,7 @@ This Dataset-level workflow can be run in a similar way, but with a different en
 
 ```bash
 analysis-runner --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.5.3-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.5.4-1 \
     --config src/align_genotype/config_template.toml \
     --dataset seqr \
     --description 'Dataset-Level QC workflow' \
@@ -49,7 +49,7 @@ A third workflow is available to run VNtyper on a set of samples, which can be u
 
 ```bash
 analysis-runner --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.5.3-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-align-genotype:0.5.4-1 \
     --config src/align_genotype/config_template.toml \
     --config src/align_genotype/vntyper.toml \
     --dataset seqr \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='Dragmap align & genotype workflow, using CPG-Flow'
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.5.3"
+version="0.5.4"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -105,7 +105,7 @@ hail = ["hail", "hailtop"]
 "src/align_genotype/jobs/somalier.py" = ["C901", "PLR0912", "PLR0913", "PLR0915"]  # ignore complexity for this script
 
 [tool.bumpversion]
-current_version = "0.5.3"
+current_version = "0.5.4"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/align_genotype/config_template.toml
+++ b/src/align_genotype/config_template.toml
@@ -19,6 +19,9 @@ genome_realignment_shards = 6
 #align_memory = 'highmem'
 #align_storage = 100
 
+# amount of storage space required - once free storage dips below this limit, the job will be killed
+align_buffer_kb = 2097152
+
 # set to use highmem workers for picard qc metrics jobs, defaults to false
 picard_metrics_use_highmem = false
 picard_metrics_ncpu = 2

--- a/src/align_genotype/jobs/align.py
+++ b/src/align_genotype/jobs/align.py
@@ -303,7 +303,25 @@ def _align_one(
     input_params = f'--interleaved=1 -b {r1_param}' if use_bazam else f'-1 {r1_param} -2 {r2_param}'
     # TODO: consider reverting to use of all threads if node capacity
     # issue is resolved: https://hail.zulipchat.com/#narrow/stream/223457-Hail-Batch-support/topic/Job.20becomes.20unresponsive
+    # add a watch_disk loop to monitor disk space, and terminate the job before entering a zombie state.
     cmd = f"""\
+    watch_disk() {{
+    local min_free_kb=2097152
+    while true; do
+      local avail
+      avail=$(df --output=avail "$BATCH_TMPDIR" | tail -1)
+      if (( avail < min_free_kb )); then
+        echo "FATAL: $BATCH_TMPDIR has ${{avail}}KB free (< ${{min_free_kb}}KB) — aborting before disk fills" >&2
+        kill -TERM -$$ 2>/dev/null
+        exit 1
+      fi
+      sleep 15
+    done
+    }}
+    watch_disk &
+    WATCHDOG_PID=$!
+    trap 'kill "$WATCHDOG_PID" 2>/dev/null' EXIT
+
     {prepare_fastq_cmd}
     dragen-os -r {dragmap_index} {input_params} \\
         --RGID {sequencing_group_name} --RGSM {sequencing_group_name} \\

--- a/src/align_genotype/jobs/align.py
+++ b/src/align_genotype/jobs/align.py
@@ -172,7 +172,7 @@ def storage_for_align_job(alignment_input: filetypes.AlignmentInput) -> int:
     return storage_gb
 
 
-def _align_one(
+def _align_one(  # noqa: PLR0915
     alignment_input: filetypes.FastqPair | filetypes.FastqOraPair | filetypes.CramPath | filetypes.BamPath,
     sequencing_group_name: str,
     job_attrs: dict,

--- a/src/align_genotype/jobs/align.py
+++ b/src/align_genotype/jobs/align.py
@@ -304,9 +304,11 @@ def _align_one(
     # TODO: consider reverting to use of all threads if node capacity
     # issue is resolved: https://hail.zulipchat.com/#narrow/stream/223457-Hail-Batch-support/topic/Job.20becomes.20unresponsive
     # add a watch_disk loop to monitor disk space, and terminate the job before entering a zombie state.
+    # default value is 2GB in KB
+    storage_buffer = config.config_retrieve(['workflow', 'align_buffer_kb'], 2097152)
     cmd = f"""\
     watch_disk() {{
-    local min_free_kb=2097152
+    local min_free_kb={storage_buffer}
     while true; do
       local avail
       avail=$(df --output=avail "$BATCH_TMPDIR" | tail -1)


### PR DESCRIPTION
# Purpose

  - Pipefail isn't correctly terminating the process when VMs run out of storage. The whole chain of tasks all need to fail before pipefail can have an effect

## Proposed Changes

  - Implement a watchdog loop to monitor for jobs which are running out of free disk
  - terminates those jobs prematurely
  - runs a `df` which is almost zero cost (reads from the OS' free-block tracker in kernel memory), _not_ `du` which would do an actual storage check (expensive)
