### PR TITLE
Make interval_list rewriting optional in Picard CollectHsMetrics job

### DIFF
--- a/src/align_genotype/config_template.toml
+++ b/src/align_genotype/config_template.toml
@@ -31,6 +31,8 @@ align_buffer_kb = 2097152
 picard_metrics_use_highmem = false
 picard_metrics_ncpu = 2
 picard_metrics_mem_gb = 8
+# Essential for the broad exome intervals, set to false for TWIST or other exome intervals
+picard_hs_metrics_reprocess_intervals = true
 
 # used to make sure we don't repeat previously completed stages
 check_expected_outputs = true

--- a/src/align_genotype/jobs/picard.py
+++ b/src/align_genotype/jobs/picard.py
@@ -213,34 +213,38 @@ def hs_metrics(
         crai=f'{cram_path}.crai',
     ).cram
 
+    if config.config_retrieve(['workflow', 'picard_hs_metrics_reprocess_intervals'], default=True):
+        # reprocess the intervals to avoid Picard crashing on mismatched md5s
+        job.command(
+            f"""\
+            # Picard is strict about the interval-list file header - contigs md5s, etc. - and
+            # if md5s do not match the ref.dict file, picard would crash. So fixing the header
+            # by converting the interval-list to bed (i.e. effectively dropping the header)
+            # and back to interval-list (effectively re-adding the header from input ref-dict).
+            # VALIDATION_STRINGENCY=SILENT does not help.
+            picard IntervalListToBed \\
+                -I {interval_file} \\
+                -O $BATCH_TMPDIR/intervals.bed
+
+            picard BedToIntervalList \\
+                -I $BATCH_TMPDIR/intervals.bed \\
+                -O $BATCH_TMPDIR/intervals.interval_list \\
+                -SD {reference.dict}
+            """
+        )
+    else:
+        # just copy the input interval list to the temp dir
+        job.command(f'cp {interval_file} $BATCH_TMPDIR/intervals.interval_list')
+
     job.command(
         f"""\
-    # Picard is strict about the interval-list file header - contigs md5s, etc. - and
-    # if md5s do not match the ref.dict file, picard would crash. So fixing the header
-    # by converting the interval-list to bed (i.e. effectively dropping the header)
-    # and back to interval-list (effectively re-adding the header from input ref-dict).
-    # VALIDATION_STRINGENCY=SILENT does not help.
-    # picard IntervalListToBed \\
-        # -I {interval_file} \\
-        # -O $BATCH_TMPDIR/intervals.bed
-
-    # picard BedToIntervalList \\
-        # -I $BATCH_TMPDIR/intervals.bed \\
-        # -O $BATCH_TMPDIR/intervals.interval_list \\
-        # -SD {reference.dict}
-
-    # Quick check to see the interval list is consistent except for the header
-    # echo "Differences between input and generated interval list:"
-    # diff <(grep -v '^@' {interval_file} | sort) <(grep -v '^@' $BATCH_TMPDIR/intervals.interval_list | sort)
-
     picard {res.java_mem_options()} \\
       CollectHsMetrics \\
       -I {cram_localised} \\
       -R {reference.base} \\
       --VALIDATION_STRINGENCY SILENT \\
-      -TI {interval_file} \\
-      -BI {interval_file} \\
-      --COVERAGE_CAP 1000000 \\
+      -TI $BATCH_TMPDIR/intervals.interval_list \\
+      -BI $BATCH_TMPDIR/intervals.interval_list \\
       -LEVEL null \\
       -LEVEL SAMPLE \\
       -LEVEL LIBRARY \\

--- a/src/align_genotype/jobs/picard.py
+++ b/src/align_genotype/jobs/picard.py
@@ -229,9 +229,9 @@ def hs_metrics(
         -O $BATCH_TMPDIR/intervals.interval_list \\
         -SD {reference.dict}
 
-    # Quick sanity check to ensure the interval list is not getting duplicated intervals
-    echo "Duplicate intervals in interval list:"
-    grep -v '^@' $BATCH_TMPDIR/intervals.interval_list | sort | uniq -d | wc -l
+    # Quick check to see the interval list is consistent except for the header
+    echo "Differences between input and generated interval list:"
+    diff <(grep -v '^@' {interval_file} | sort) <(grep -v '^@' $BATCH_TMPDIR/intervals.interval_list | sort)
 
     picard {res.java_mem_options()} \\
       CollectHsMetrics \\

--- a/src/align_genotype/jobs/picard.py
+++ b/src/align_genotype/jobs/picard.py
@@ -220,26 +220,26 @@ def hs_metrics(
     # by converting the interval-list to bed (i.e. effectively dropping the header)
     # and back to interval-list (effectively re-adding the header from input ref-dict).
     # VALIDATION_STRINGENCY=SILENT does not help.
-    picard IntervalListToBed \\
-        -I {interval_file} \\
-        -O $BATCH_TMPDIR/intervals.bed
+    # picard IntervalListToBed \\
+        # -I {interval_file} \\
+        # -O $BATCH_TMPDIR/intervals.bed
 
-    picard BedToIntervalList \\
-        -I $BATCH_TMPDIR/intervals.bed \\
-        -O $BATCH_TMPDIR/intervals.interval_list \\
-        -SD {reference.dict}
+    # picard BedToIntervalList \\
+        # -I $BATCH_TMPDIR/intervals.bed \\
+        # -O $BATCH_TMPDIR/intervals.interval_list \\
+        # -SD {reference.dict}
 
     # Quick check to see the interval list is consistent except for the header
-    echo "Differences between input and generated interval list:"
-    diff <(grep -v '^@' {interval_file} | sort) <(grep -v '^@' $BATCH_TMPDIR/intervals.interval_list | sort)
+    # echo "Differences between input and generated interval list:"
+    # diff <(grep -v '^@' {interval_file} | sort) <(grep -v '^@' $BATCH_TMPDIR/intervals.interval_list | sort)
 
     picard {res.java_mem_options()} \\
       CollectHsMetrics \\
       -I {cram_localised} \\
       -R {reference.base} \\
       --VALIDATION_STRINGENCY SILENT \\
-      -TI $BATCH_TMPDIR/intervals.interval_list \\
-      -BI $BATCH_TMPDIR/intervals.interval_list \\
+      -TI {interval_file} \\
+      -BI {interval_file} \\
       --COVERAGE_CAP 1000000 \\
       -LEVEL null \\
       -LEVEL SAMPLE \\

--- a/src/align_genotype/jobs/picard.py
+++ b/src/align_genotype/jobs/picard.py
@@ -229,9 +229,13 @@ def hs_metrics(
         -O $BATCH_TMPDIR/intervals.interval_list \\
         -SD {reference.dict}
 
+    # Quick sanity check to ensure the interval list is not getting duplicated intervals
+    echo "Duplicate intervals in interval list:"
+    grep -v '^@' $BATCH_TMPDIR/intervals.interval_list | sort | uniq -d | wc -l
+
     picard {res.java_mem_options()} \\
       CollectHsMetrics \\
-      -I $BATCH_TMPDIR/input.bam \\
+      -I {cram_localised} \\
       -R {reference.base} \\
       --VALIDATION_STRINGENCY SILENT \\
       -TI $BATCH_TMPDIR/intervals.interval_list \\

--- a/src/align_genotype/jobs/picard.py
+++ b/src/align_genotype/jobs/picard.py
@@ -229,12 +229,20 @@ def hs_metrics(
         -O $BATCH_TMPDIR/intervals.interval_list \\
         -SD {reference.dict}
 
+    # Convert CRAM to BAM for Picard CollectHsMetrics
+    # CRAMs written with htsjdk ~3.0.0 break Picard CollectHsMetrics, so we convert to BAM first
+    samtools view -b \\
+        -T {reference.base} \\
+        -o $BATCH_TMPDIR/input.bam \\
+        {cram_localised}
+
+    samtools index $BATCH_TMPDIR/input.bam
+
     picard {res.java_mem_options()} \\
       CollectHsMetrics \\
-      -I {cram_localised} \\
+      -I $BATCH_TMPDIR/input.bam \\
       -R {reference.base} \\
       --VALIDATION_STRINGENCY SILENT \\
-      --CLIP_OVERLAPPING_READS false \\
       -TI $BATCH_TMPDIR/intervals.interval_list \\
       -BI $BATCH_TMPDIR/intervals.interval_list \\
       -LEVEL null \\

--- a/src/align_genotype/jobs/picard.py
+++ b/src/align_genotype/jobs/picard.py
@@ -229,15 +229,6 @@ def hs_metrics(
         -O $BATCH_TMPDIR/intervals.interval_list \\
         -SD {reference.dict}
 
-    # Convert CRAM to BAM for Picard CollectHsMetrics
-    # CRAMs written with htsjdk ~3.0.0 break Picard CollectHsMetrics, so we convert to BAM first
-    samtools view -b \\
-        -T {reference.base} \\
-        -o $BATCH_TMPDIR/input.bam \\
-        {cram_localised}
-
-    samtools index $BATCH_TMPDIR/input.bam
-
     picard {res.java_mem_options()} \\
       CollectHsMetrics \\
       -I $BATCH_TMPDIR/input.bam \\
@@ -245,6 +236,7 @@ def hs_metrics(
       --VALIDATION_STRINGENCY SILENT \\
       -TI $BATCH_TMPDIR/intervals.interval_list \\
       -BI $BATCH_TMPDIR/intervals.interval_list \\
+      --COVERAGE_CAP 1000000 \\
       -LEVEL null \\
       -LEVEL SAMPLE \\
       -LEVEL LIBRARY \\

--- a/src/align_genotype/jobs/picard.py
+++ b/src/align_genotype/jobs/picard.py
@@ -234,6 +234,7 @@ def hs_metrics(
       -I {cram_localised} \\
       -R {reference.base} \\
       --VALIDATION_STRINGENCY SILENT \\
+      --CLIP_OVERLAPPING_READS false \\
       -TI $BATCH_TMPDIR/intervals.interval_list \\
       -BI $BATCH_TMPDIR/intervals.interval_list \\
       -LEVEL null \\


### PR DESCRIPTION
# Purpose

  - This PR attempts to resolve the Picard CollectHsMetrics bug that occurs when processing exomes with newer Picard versions. The v2.27.4 image processes without issue, but any of the v3.x images always seem to lead to this error right at the end of the processing: 
 ```
  Exception in thread "main" picard.PicardException: numbers of bases in the base quality histogram and the coverage histogram are not equal
	at picard.analysis.directed.TargetMetricsCollector$PerUnitTargetMetricCollector.calculateTheoreticalHetSensitivity(TargetMetricsCollector.java:802)
	at picard.analysis.directed.TargetMetricsCollector$PerUnitTargetMetricCollector.finish(TargetMetricsCollector.java:702)
	at picard.metrics.MultiLevelCollector$Distributor.finish(MultiLevelCollector.java:142)
	at picard.metrics.MultiLevelCollector.finish(MultiLevelCollector.java:324)
	at picard.analysis.directed.CollectTargetedMetrics.doWork(CollectTargetedMetrics.java:168)
	at picard.cmdline.CommandLineProgram.instanceMain(CommandLineProgram.java:281)
	at picard.cmdline.PicardCommandLine.instanceMain(PicardCommandLine.java:105)
	at picard.cmdline.PicardCommandLine.main(PicardCommandLine.java:115)
```

This failure mode occurs in every exome processed, and there are no other bug reports in the Picard repo issues or elsewhere mentioning this, so it might be due to bespoke code we've added to reformat the interval lists. 


## Attempted Fixes

  - Try ensuring Picard v3.5.0 has htsjdk 5.0.0 installed instead of force overriding with v4.3.0 - [does not work](https://batch.hail.populationgenomics.org.au/batches/1136052/jobs/1)
  - Try `--CLIP_OVERLAPPING_READS false` - [does not work](https://batch.hail.populationgenomics.org.au/batches/1136054/jobs/1)
  - Try converting CRAM to BAM with samtools first - [does not work](https://batch.hail.populationgenomics.org.au/batches/1136056/jobs/1)
  - Try increasing coverage cap drastically with `--COVERAGE_CAP 1000000` - [does not work](https://batch.hail.populationgenomics.org.au/batches/1136063/jobs/1)
  - Try checking the before and after interval_list changes are fine - no differences (aside from headers) (Picard 2.27.4 [job](https://batch.hail.populationgenomics.org.au/batches/1136071/jobs/1) | Picard 3.5.0 [job](https://batch.hail.populationgenomics.org.au/batches/1136067/jobs/1))
  - Try removing the interval_list changes altogether - [WORKS](https://batch.hail.populationgenomics.org.au/batches/1136073/jobs/1) ??? and [here](https://batch.hail.populationgenomics.org.au/batches/1136084) too
    - DOES NOT WORK for the original Broad exome evaluation regions interval list - this does seem to need the reheadering, but then causes the error for CollectHsMetrics with Picard v3.x

## Conclusion?
- When using the Broad exome evaluation regions interval list, we need to reformat the list and push it through with Picard v2.27.4
- When using other interval lists (e.g. TWIST2), we can skip the reformatting and use Picard v3.x

## Proposed Changes

- Make the interval_list reformatting code at the start of the job command optional

## Checklist

- [ ] Related GitHub Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
